### PR TITLE
Add plan 0002: Redesigning Ylmish around real CRDT merging

### DIFF
--- a/doc/plans/0002-assumptions/README.md
+++ b/doc/plans/0002-assumptions/README.md
@@ -1,0 +1,20 @@
+# Yjs assumption experiments for plan 0002
+
+Runnable evidence for the "Validated assumptions" table in
+[`../0002-ylmish-redesign.md`](../0002-ylmish-redesign.md).
+
+```bash
+npm install yjs   # any 13.6.x
+node experiments.mjs    # U1–U12
+node experiments2.mjs   # U5b/U5c, U13–U15
+```
+
+Each experiment prints a JSON result; the `note` fields state what the outcome
+implies. Step 1 of the plan ports these to `tests/Ylmish.Tests/Y.Assumptions.fs`
+so CI pins the semantics against Yjs upgrades.
+
+Notable: in U5/U5b the corruption from re-setting an integrated Y type does
+**not** throw at the call site — Yjs logs a `TypeError` internally and the doc
+becomes unsyncable only later (`applyUpdate` on a peer throws). That's why the
+binding layer must make re-parenting impossible by construction rather than
+try/catch around it.

--- a/doc/plans/0002-assumptions/experiments.mjs
+++ b/doc/plans/0002-assumptions/experiments.mjs
@@ -1,0 +1,247 @@
+import * as Y from 'yjs'
+
+const results = []
+function report(name, obj) {
+  results.push({ name, ...obj })
+  console.log(`\n=== ${name} ===`)
+  console.log(JSON.stringify(obj, null, 2))
+}
+
+function syncBoth(a, b) {
+  const ua = Y.encodeStateAsUpdate(a)
+  const ub = Y.encodeStateAsUpdate(b)
+  Y.applyUpdate(a, ub)
+  Y.applyUpdate(b, ua)
+}
+
+// U1: doc.getMap() with no args / repeated calls — same instance? key?
+{
+  const doc = new Y.Doc()
+  const m1 = doc.getMap()
+  const m2 = doc.getMap()
+  const m3 = doc.getMap('')
+  report('U1 root map identity', {
+    sameInstanceNoArgs: m1 === m2,
+    noArgsEqualsEmptyString: m1 === m3,
+    shareKeys: [...doc.share.keys()],
+  })
+}
+
+// U2a: nested-type initialization race — each client creates its own Y.Array under same map key
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const a1 = new Y.Array(); a1.push(['from-d1'])
+  d1.getMap().set('todos', a1)
+  const a2 = new Y.Array(); a2.push(['from-d2'])
+  d2.getMap().set('todos', a2)
+  syncBoth(d1, d2)
+  report('U2a nested init race (each creates own Y.Array under same key)', {
+    d1: d1.getMap().get('todos').toArray(),
+    d2: d2.getMap().get('todos').toArray(),
+    note: 'if one subtree wins wholesale, items from loser are LOST',
+  })
+}
+
+// U2b: same scenario but with ROOT-level arrays (doc.getArray('todos'))
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  d1.getArray('todos').push(['from-d1'])
+  d2.getArray('todos').push(['from-d2'])
+  syncBoth(d1, d2)
+  report('U2b root-level arrays same name', {
+    d1: d1.getArray('todos').toArray(),
+    d2: d2.getArray('todos').toArray(),
+    note: 'root types with same name merge, no wholesale loss',
+  })
+}
+
+// U3: concurrent edits to same Y.Text nested in a map (created ONCE, then synced)
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const t = new Y.Text(); t.insert(0, 'hello')
+  d1.getMap().set('body', t)
+  syncBoth(d1, d2) // both now share the same text
+  // concurrent edits
+  d1.getMap().get('body').insert(5, ' world')   // "hello world"
+  d2.getMap().get('body').insert(0, 'oh, ')      // "oh, hello"
+  syncBoth(d1, d2)
+  report('U3 concurrent edits on shared nested Y.Text', {
+    d1: d1.getMap().get('body').toString(),
+    d2: d2.getMap().get('body').toString(),
+    converged: d1.getMap().get('body').toString() === d2.getMap().get('body').toString(),
+  })
+}
+
+// U3b: string field stored as plain map value — concurrent set (the issue #83 failure mode)
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  d1.getMap().set('body', 'hello')
+  syncBoth(d1, d2)
+  d1.getMap().set('body', 'hello world')
+  d2.getMap().set('body', 'oh, hello')
+  syncBoth(d1, d2)
+  report('U3b concurrent plain-string set (LWW clobber)', {
+    d1: d1.getMap().get('body'),
+    d2: d2.getMap().get('body'),
+  })
+}
+
+// U4: what decides the LWW winner for concurrent map.set? clientID? insertion order?
+{
+  const outcomes = []
+  for (const [c1, c2] of [[1, 2], [2, 1], [100, 5]]) {
+    const d1 = new Y.Doc(); d1.clientID = c1
+    const d2 = new Y.Doc(); d2.clientID = c2
+    d1.getMap().set('k', 'v-from-' + c1)
+    d2.getMap().set('k', 'v-from-' + c2)
+    // apply d2's update to d1 first, then reverse — check order independence
+    syncBoth(d1, d2)
+    outcomes.push({ c1, c2, d1: d1.getMap().get('k'), d2: d2.getMap().get('k') })
+  }
+  report('U4 concurrent map.set winner rule', { outcomes, note: 'winner should be higher clientID, deterministic, NOT wall-clock' })
+}
+
+// U5: can an integrated Y type be moved / re-set elsewhere?
+{
+  const d1 = new Y.Doc()
+  const t = new Y.Text(); t.insert(0, 'x')
+  d1.getMap().set('a', t)
+  let moveError = null
+  try {
+    d1.getMap().set('b', t) // re-set same instance to another key
+  } catch (e) { moveError = e.message }
+  const bIsA = d1.getMap().get('a') === d1.getMap().get('b')
+  report('U5 move integrated type', {
+    moveError,
+    reSetSucceededButAliased: bIsA,
+    aStr: String(d1.getMap().get('a')),
+    bStr: (() => { try { return String(d1.getMap().get('b')) } catch (e) { return 'ERROR: ' + e.message } })(),
+  })
+}
+
+// U6: transaction origins — do they propagate to observers, and does applyUpdate carry its own origin?
+{
+  const d1 = new Y.Doc()
+  const seen = []
+  d1.getMap().observe((e, tr) => { seen.push({ origin: String(tr.origin), local: tr.local }) })
+  d1.transact(() => d1.getMap().set('k', 1), 'my-origin')
+  d1.getMap().set('k', 2) // no origin
+  const d2 = new Y.Doc()
+  d2.getMap().set('k', 3)
+  Y.applyUpdate(d1, Y.encodeStateAsUpdate(d2), 'remote-origin')
+  report('U6 transaction origins', { seen })
+}
+
+// U7: observeDeep on root map — does it fire for nested Y.Text edits with paths?
+{
+  const d1 = new Y.Doc()
+  const t = new Y.Text()
+  d1.getMap().set('body', t)
+  const events = []
+  d1.getMap().observeDeep((evts) => {
+    for (const e of evts) events.push({ type: e.constructor.name, path: e.path })
+  })
+  t.insert(0, 'hi')
+  const arr = new Y.Array()
+  d1.getMap().set('list', arr)
+  arr.push([new Y.Map()])
+  arr.get(0).set('inner', 'v')
+  report('U7 observeDeep nested events', { events })
+}
+
+// U8: concurrent Y.Array inserts at same position — both survive?
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const arr = new Y.Array(); arr.push(['base'])
+  d1.getMap().set('xs', arr)
+  syncBoth(d1, d2)
+  d1.getMap().get('xs').insert(0, ['from-d1'])
+  d2.getMap().get('xs').insert(0, ['from-d2'])
+  syncBoth(d1, d2)
+  report('U8 concurrent array inserts', {
+    d1: d1.getMap().get('xs').toArray(),
+    d2: d2.getMap().get('xs').toArray(),
+  })
+}
+
+// U9: delete a nested map while the other client edits inside it
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const item = new Y.Map(); item.set('title', 'a')
+  const arr = new Y.Array(); arr.push([item])
+  d1.getMap().set('xs', arr)
+  syncBoth(d1, d2)
+  d1.getMap().get('xs').delete(0, 1)               // d1 deletes the item
+  d2.getMap().get('xs').get(0).set('title', 'b')    // d2 edits inside it
+  syncBoth(d1, d2)
+  report('U9 delete vs edit-inside', {
+    d1len: d1.getMap().get('xs').length,
+    d2len: d2.getMap().get('xs').length,
+    note: 'deletion should win; concurrent edit lost',
+  })
+}
+
+// U10: what primitive value types does Y.Map support?
+{
+  const d = new Y.Doc()
+  const m = d.getMap()
+  const vals = { num: 42, float: 1.5, bool: true, nul: null, str: 's', obj: { a: 1 }, arr: [1, 2] }
+  const res = {}
+  for (const [k, v] of Object.entries(vals)) {
+    try { m.set(k, v); res[k] = { ok: true, back: m.get(k), type: typeof m.get(k) } }
+    catch (e) { res[k] = { ok: false, err: e.message } }
+  }
+  let undef = null
+  try { m.set('undef', undefined); undef = { ok: true, back: String(m.get('undef')) } } catch (e) { undef = { ok: false, err: e.message } }
+  res.undef = undef
+  report('U10 primitive types in Y.Map', res)
+}
+
+// U11: Y.Text delta granularity — does a Y.Text created-then-populated in same tx emit sane deltas after sync?
+// And: does re-assigning a NEW Y.Text over an old key kill the old one for remote editors?
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const t1 = new Y.Text(); t1.insert(0, 'v1')
+  d1.getMap().set('body', t1)
+  syncBoth(d1, d2)
+  const t2ref = d2.getMap().get('body')
+  // d1 replaces the Y.Text entirely (like a materialize would)
+  const tNew = new Y.Text(); tNew.insert(0, 'v2')
+  d1.getMap().set('body', tNew)
+  // d2 concurrently edits the OLD text
+  t2ref.insert(2, '!')
+  syncBoth(d1, d2)
+  report('U11 replace Y.Text vs concurrent edit of old', {
+    d1: String(d1.getMap().get('body')),
+    d2: String(d2.getMap().get('body')),
+    note: 'replacement wins; old edits lost — why materialize-per-update breaks CRDT merging',
+  })
+}
+
+// U12: offline convergence — two docs never synced start with "same" initial state via independent materialize; how bad is it?
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  // both do what withYlmish init does today: materialize the same initial model independently
+  for (const d of [d1, d2]) {
+    const items = new Y.Array(); items.push(['seed'])
+    d.getMap().set('items', items)
+    const t = new Y.Text(); t.insert(0, 'seed-text')
+    d.getMap().set('body', t)
+  }
+  syncBoth(d1, d2)
+  report('U12 independent identical initialization', {
+    items: d1.getMap().get('items').toArray(),
+    body: String(d1.getMap().get('body')),
+    note: 'identical independent init still duplicates or drops — structure is not content-addressed',
+  })
+}
+
+console.log('\n\nDONE. ' + results.length + ' experiments run.')

--- a/doc/plans/0002-assumptions/experiments2.mjs
+++ b/doc/plans/0002-assumptions/experiments2.mjs
@@ -1,0 +1,83 @@
+import * as Y from 'yjs'
+
+function syncBoth(a, b) {
+  Y.applyUpdate(a, Y.encodeStateAsUpdate(b))
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a))
+}
+
+// U5b: re-set integrated type, then sync to a second doc — is the doc corrupted?
+{
+  const d1 = new Y.Doc()
+  const t = new Y.Text(); t.insert(0, 'x')
+  d1.getMap().set('a', t)
+  let err = null
+  try { d1.getMap().set('b', t) } catch (e) { err = e.message }
+  const d2 = new Y.Doc()
+  let syncErr = null
+  try { Y.applyUpdate(d2, Y.encodeStateAsUpdate(d1)) } catch (e) { syncErr = e.message }
+  console.log('U5b re-set integrated type:', JSON.stringify({
+    setErr: err,
+    syncErr,
+    d2a: (() => { try { return String(d2.getMap().get('a')) } catch (e) { return 'ERR ' + e.message } })(),
+    d2b: (() => { try { return String(d2.getMap().get('b')) } catch (e) { return 'ERR ' + e.message } })(),
+  }))
+}
+
+// U5c: insert a type integrated in doc1 into doc2 — cross-doc reuse
+{
+  const d1 = new Y.Doc()
+  const t = new Y.Text(); t.insert(0, 'x')
+  d1.getMap().set('a', t)
+  const d2 = new Y.Doc()
+  let err = null
+  try { d2.getMap().set('a', t) } catch (e) { err = e.message }
+  console.log('U5c cross-doc reuse:', JSON.stringify({ err }))
+}
+
+// U13: concurrent "move" as delete+insert — duplication?
+{
+  const d1 = new Y.Doc(); d1.clientID = 1
+  const d2 = new Y.Doc(); d2.clientID = 2
+  const arr = new Y.Array(); arr.push(['a', 'b', 'c'])
+  d1.getMap().set('xs', arr)
+  syncBoth(d1, d2)
+  // both concurrently move 'a' to the end (delete@0, insert@end)
+  const move = (d) => {
+    const xs = d.getMap().get('xs')
+    d.transact(() => { const v = xs.get(0); xs.delete(0, 1); xs.push([v]) })
+  }
+  move(d1); move(d2)
+  syncBoth(d1, d2)
+  console.log('U13 concurrent move:', JSON.stringify({
+    d1: d1.getMap().get('xs').toArray(),
+    d2: d2.getMap().get('xs').toArray(),
+  }))
+}
+
+// U14: does a single doc.transact spanning many nested types produce ONE observeDeep batch?
+{
+  const d = new Y.Doc()
+  const t = new Y.Text(); const a = new Y.Array()
+  d.getMap().set('t', t); d.getMap().set('a', a)
+  let batches = 0, evtsTotal = 0
+  d.getMap().observeDeep((evts) => { batches++; evtsTotal += evts.length })
+  d.transact(() => { t.insert(0, 'hi'); a.push([1]); d.getMap().set('k', 'v') })
+  console.log('U14 transact batching:', JSON.stringify({ batches, evtsTotal }))
+}
+
+// U15: update exchange when only a subset of keys is understood — forward compat.
+// Old client has {v1key}, new client adds {v2key with Y.Text}. Old client applies update fine?
+{
+  const oldc = new Y.Doc(); const newc = new Y.Doc()
+  oldc.getMap().set('v1', 'old-data')
+  syncBoth(oldc, newc)
+  const t = new Y.Text(); t.insert(0, 'new-data')
+  newc.getMap().set('v2', t)
+  let err = null
+  try { syncBoth(oldc, newc) } catch (e) { err = e.message }
+  console.log('U15 unknown keys tolerated:', JSON.stringify({
+    err,
+    oldSees: [...oldc.getMap().keys()],
+    v1: oldc.getMap().get('v1'),
+  }))
+}

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -4,7 +4,7 @@ Fixes [#83](https://github.com/NickDarvey/Ylmish/issues/83).
 
 ## Motivation
 
-`Program.withYlmish` today synchronizes by **materializing the whole encoded state tree** into the Y.Doc on every Elmish update, and reading it back wholesale on every Y.Doc change. Consequences (all reproduced empirically, see [Validated assumptions](#validated-assumptions-about-yjs)):
+`Program.withYlmish` today synchronizes by **materializing the whole encoded state tree** into the Y.Doc on every Elmish update, and reading it back wholesale on every Y.Doc change. Consequences (all reproduced empirically, see [Validated assumptions](#validated-assumptions)):
 
 - String fields are atomic map values, so concurrent edits to the same field resolve last-writer-wins instead of merging. The canonical collaborative use case — two people typing in the same text body — silently loses one side's work.
 - Every update replaces nested `Y.Array`/`Y.Map`/`Y.Text` instances wholesale, which discards *any* concurrent remote edits inside them, not just text.
@@ -17,85 +17,110 @@ This plan replaces the materialize path with a **live binding**: the codec descr
 
 ## Design inputs
 
-Decisions taken with Nick (2026-07-02):
+Decisions taken with Nick:
 
 | Question | Decision |
 | --- | --- |
-| How does collaborative text appear in the consumer's model? | **A dedicated `Ylmish.Text` type** that carries edit intent, not a plain diffed `string`. |
-| Which layers are public? | **Elmish-first.** `Program.withYlmish` + the codec are the supported surface. The adaptive↔Y attach primitives stay internal so they can change freely. |
-| Who seeds a fresh document? | **Decode-empty = init.** The library never writes structure eagerly. An empty/partial doc decodes through the consumer's decoder (which has access to the current model); containers are created lazily by the first client that *edits* them, atomically. No seeding race by construction. |
+| How does collaborative text appear in the consumer's model? | **A dedicated `Ylmish.Text` type** that carries edit intent, not a plain diffed `string`. (Reaffirmed after reviewing the executed branch, which shipped `aval<string>` + affix diff and proved it *converges* fine — the dedicated type is an interleaving-fidelity and editor-integration choice, and `Text.edit` keeps the zero-ceremony path.) |
+| Which layers are public? | **Elmish-first, with named exceptions.** `Program.withYlmish` + the codec are the primary surface. **Yjs and Elmish are acceptable public dependencies**; Fable.Yjs types appear verbatim in the `CustomElement` escape hatch so a consumer can bind, say, a real `Y.Text` to an editor. **Adaptive trends toward encapsulation**: the Adaptify-generated `Create`/`Update` can't be hidden yet, but nothing else should require the consumer to touch `aval`/`alist`/`amap`, and new public contracts (notably `CustomElement`) must be Adaptive-free. |
+| Who seeds a fresh document? | **Decode-empty = init.** The library never writes structure eagerly. An empty/partial doc decodes through the consumer's decoder (which has access to the current model); containers are created lazily by the first client that *edits* them, atomically. |
+| The nested first-create race (U2a) | **Accepted as a documented limitation, solved by application design.** If two offline peers each *first-create* the same nested container and later sync, one subtree wins wholesale. The app-level rule: anything that can be *created* offline needs a consumer-supplied unique key (`Encode.map` keyed by it), so independent offline creations occupy distinct keys and never race. Editing an *existing* field offline is the normal CRDT case and merges. The library documents this rule; it does not contort the document layout to dissolve the race. |
 | Packaging | **One `Ylmish` package** (plus `Fable.Yjs`); opinionated extras are separate namespaces you must explicitly `open`. |
-| Per-field merge menu | **LWW registers, mergeable Text, and mergeable lists (Y.Array insert/delete merge)** — the three merge behaviours Yjs gives us natively. Richer strategies (counters, timestamped LWW, custom reduces) deferred until a consumer needs them. The demo must exercise list merging, not just text. |
-| List semantics | **`Encode.list` → Y.Array with documented limits** (concurrent reorder duplicates; delete beats concurrent edit-inside). Additionally ship **`Encode.map` as the keyed primitive** (items in a Y.Map by consumer-supplied stable key) so consumers who have keys can build ordering themselves — e.g. fractional indexing as an order field. Ylmish provides the primitive, not the opinionated ordering machinery. |
-| Migrations | **Defer entirely.** No Migrations module yet. The codec must keep migrations *expressible* (decoders compose, encoders combine, the runtime preserves unknown keys) and the docs show the dual-key recipe, but nothing ships until a real consumer validates the need. |
-| Demo form | **CLI, as today.** A Node script whose output demonstrates the system under interesting concurrency: offline divergence, concurrent text edits interleaving, concurrent list inserts merging, LWW clobber shown honestly, reconvergence after sync. |
+| Per-field merge menu | **LWW registers, mergeable Text, mergeable lists (Y.Array), keyed element-wise maps** — plus **`Encode.atomic`** (deliberate wholesale-LWW subtree) and **`Encode.custom`** (the `CustomElement` escape hatch for consumer-defined merge strategies and direct Y-type access). Opinionated strategies built *on* the hatch (counters, timestamped LWW) stay out of core. The demo must exercise list and keyed-map merging, not just text. |
+| List semantics | **`Encode.list` is for value sequences** (insert/delete merge, diff-reconciled). **Records with identity go in `Encode.map`** over `HashMap<key, _>` — this is now a hard rule, not a preference, because Adaptify's list deltas are positional (see L1) and would corrupt nested collaborative state under insert/reorder. Ordering of keyed items is the consumer's concern (fractional-index recipe in docs). |
+| Migrations | **Defer entirely.** No Migrations module. The codec keeps migrations *expressible* (decoders compose, encoders combine, the runtime preserves unknown keys) and the docs show the dual-key recipe. (The executed branch independently built migration helpers and then cut them — treat that as confirmation.) |
+| Demo form | **CLI.** A Node script whose output demonstrates the system under interesting concurrency: offline divergence, text interleaving, list merges, keyed-map merges, an honest LWW clobber, reconvergence. |
 
-## Validated assumptions about Yjs
+## Lessons imported from `claude/github-issues-visibility-8k12g3`
 
-Runnable scripts: [`0002-assumptions/`](./0002-assumptions/) (`node experiments.mjs`, yjs 13.6.x). Step 1 of the plan pins these as characterization tests in CI.
+That branch executed its own plans 0002–0009 to close #83 by accretion (flatten collaborative leaves to scheme-named top-level roots, keep `materialize` for the structural rest). This plan takes the other architecture — bind nested types in place, delete `materialize` — but its evidence is real and is folded in here:
+
+| # | Lesson (their evidence) | Consequence in this plan |
+| --- | --- | --- |
+| L1 | **Adaptify list deltas are positional, not keyed** (their 0006 Step 1, pinned in `Adaptive.Spike.fs`). The idiomatic rebuild `{ m with Items = recompute() }` yields O(n) positional value-rewrites, and `ChangeableModelList` **rebinds nested adaptive objects by position** — a nested `Y.Text` hung off item *i* gets hijacked by whatever lands at position *i*. | `Encode.list` is restricted to value sequences; items may not contain text/custom leaves (runtime error pointing at `Encode.map`). Step 1 re-pins this characterization in our suite. The plan's O(delta) claims are scoped: lists are diff-reconciled by value, maps are keyed by construction (`HashMap` → keyed `amap` reconcile, their 0008 Step 0a). |
+| L2 | **Differential testing against a raw-Yjs oracle** (their 0006 harness): replay per-replica schedules under a delivery policy, compare the full bridge against hand-written Yjs, plus property-based random schedules. It caught the whole-container-LWW bug red-handed and *discriminated* (green on sequential). | Adopted as this plan's verification backbone (Steps 2 and 9). No self-authored spec to be wrong about. |
+| L3 | **Common-affix diff produces minimal text deltas** (their A5: one char change = 2 ops, not clear+reinsert; Myers unnecessary). | Validates `Text.edit`'s implementation strategy and the "plain `<input>` stays cheap" claim. |
+| L4 | **Read-back fragmentation was a consequence of their layout.** Flattening leaves to separate roots meant root-map `observeDeep` never saw remote text/custom edits → per-clist observers → merged read-back trees → `afterTransaction` hooks, with real crashes en route (re-entrant `Y.Text` edit during a remote apply; `"cannot mark object without transaction"`). | Bind-in-place keeps **one** `observeDeep` (nested events reach the root, U7) and origin tokens suppress echo (U6) — structurally avoiding that bug class. Their two crashes become named regression tests in Step 6. Their lesson that connect realizes the adaptive graph (all mutations must be inside `transact`) is folded into Step 5's contract. |
+| L5 | **Root kind drift throws** (their A2): re-getting a root under a different type is an error, and schema drift needs a clear message. | The binding layer detects kind mismatch (encoded kind vs existing Y type) and surfaces a structured decode/bind error rather than a Yjs internal throw. Step 5 test. |
+| L6 | **The `CustomElement` contract shape is proven** (their 0003/0005/0008): `Connect : BindContext -> IDisposable`, an Adaptive-free merged-value read (`Value`), a working consumer counter that *sums* concurrent increments, and "one attach contract" (built-in text rides the same seam). Their `Subscribe` member existed only because their layout put customs outside `observeDeep`'s reach. | Step 8 adopts Connect + Value (Adaptive-free, per the encapsulation decision) but **drops `Subscribe`** — under bind-in-place, custom read-back rides the same root `observeDeep`. `BindContext` exposes real Fable.Yjs types; that's now an explicit feature (bind a `Y.Text` to an editor). |
+| L7 | **"The model's type is the merge choice"** (their 0008 taxonomy) and **naming-id ≠ ordering-id** (their 0004: immutable identity for structure, mutable fractional `order` field for display order, `fractional-indexing` as consumer recipe). | Adopted verbatim: the taxonomy table below and in the README; the fractional-index recipe in `recipes.md`. |
+| L8 | **Their 0009 problem (nested records clobber per-record) dissolves under bind-in-place.** They needed dotted-key flattening + escaping because nested `Y.Map`s were re-created each update. | We get per-field merge of nested records for free — a nested object is a bound `Y.Map` whose keys are bound individually. `Encode.atomic` is still worth shipping as the *deliberate* wholesale-LWW opt-out (their insight that atomic replacement is sometimes what you want). Step 5 proves per-field nested merge; Step 4 adds `atomic`. |
+| L9 | **Move/reorder duplication and delete-beats-edit are livable, pinned limits** (their harness pinned concurrent same-item moves may duplicate; ours pinned the same, U13/U9). | Documented limits; the keyed-map + order-field pattern is the recommended shape for reorderable collections precisely because a reorder becomes an order-field LWW write, not a structural move. |
+
+What we deliberately do **not** import: the `Scheme` seam and root-flattening layout (its robustness benefit is now an accepted app-design concern — unique keys for offline-creatable entities — and its costs were a fragmented wire format and read path); the `materialize` hybrid; boolean reentrancy flags (origins are sounder, and are what `Y.UndoManager` will want); stringly primitives (`Decode.bool` via `string v = "true"`).
+
+## Validated assumptions
+
+Runnable scripts: [`0002-assumptions/`](./0002-assumptions/) (`node experiments.mjs`, yjs 13.6.x). Step 1 pins these as characterization tests in CI — both the Yjs set and the Adaptive set (L1).
 
 | # | Unknown | Result | Design consequence |
 | --- | --- | --- | --- |
 | U1 | What does argless `doc.getMap()` return? | The root map named `''`; same instance every call. | Root binding is stable; no need to force consumers to name a root map. |
-| U2a | Two clients each create a nested type under the same map key, then sync. | One client's **entire subtree wins**; the other's data is silently discarded. | Never create containers eagerly at init. Containers are created only on first local edit; decode of an empty doc yields the consumer's init state. |
+| U2a | Two clients each create a nested type under the same map key, then sync. | One client's **entire subtree wins**; the other's data is silently discarded. | Never create containers eagerly at init; create lazily on first local edit. Residual first-create race is an **accepted, documented limitation**: offline-creatable entities need consumer-supplied unique keys (`Encode.map`). |
 | U2b | Same race with *root-level* types (`doc.getArray "todos"`). | Merges by name; both sides' items survive. | Root types are safe to get-or-create. |
 | U3 | Concurrent edits to one shared nested `Y.Text`. | Interleave and converge. | The whole point. Text must bind to an existing instance, created once. |
 | U3b | Concurrent `map.set` of a plain string. | LWW clobber — issue #83's failure mode. | Plain values are honest LWW registers; the codec must let consumers choose text vs register per field. |
-| U4 | What decides the LWW winner? | Deterministic, order-independent: **higher clientID wins** among concurrent sets. Not wall-clock. | Document honestly: "last writer" is an arbitrary-but-convergent tiebreak. Timestamped LWW would be an opt-in module. |
+| U4 | What decides the LWW winner? | Deterministic, order-independent: **higher clientID wins** among concurrent sets. Not wall-clock. | Document honestly: "last writer" is an arbitrary-but-convergent tiebreak. |
 | U5 | Re-set an already-integrated Y type instance under another key. | **No exception at the call site; the doc corrupts** — later syncs throw and content is lost. | The public API must make re-parenting impossible by construction. The binding layer binds each model field to exactly one shared-type instance and never reuses instances. |
-| U6 | Do transaction origins propagate? | Yes: `doc.transact(fn, origin)` origins and `applyUpdate`'s origin both reach observers, with `local` flag. | Echo suppression via a per-binding origin token, replacing the current boolean-flag reentrancy guards. |
-| U7 | Does `observeDeep` on the root see nested edits? | Yes, typed events with paths (`["list", 0]`) and per-type deltas. | The decode direction can route remote deltas precisely. |
-| U8 | Concurrent Y.Array inserts at the same position. | Both survive, deterministic order. | Lists merge; safe default. |
-| U9 | Delete an item vs concurrent edit inside it. | Delete wins; the edit is lost. | Documented list semantics. |
+| U6 | Do transaction origins propagate? | Yes: `doc.transact(fn, origin)` origins and `applyUpdate`'s origin both reach observers, with `local` flag. | Echo suppression via a per-binding origin token, replacing boolean reentrancy flags. |
+| U7 | Does `observeDeep` on the root see nested edits? | Yes, typed events with paths (`["list", 0]`) and per-type deltas. | One observer covers the whole bound tree — including custom elements (L4, L6). |
+| U8 | Concurrent Y.Array inserts at the same position. | Both survive, deterministic order. | Lists merge; safe default for value sequences. |
+| U9 | Delete an item vs concurrent edit inside it. | Delete wins; the edit is lost. | Documented limit. |
 | U10 | What primitives can Y.Map hold? | Any JSON value (number, bool, null, string, plain objects/arrays). | The codec's `Element<string>` (strings only) is an unnecessary restriction; v2 elements carry typed primitives. |
 | U11 | Replace a nested Y.Text with a fresh one while a peer edits the old one. | Replacement wins; the peer's edits are lost. | Precisely why materialize-per-update can never merge. Bind, never replace. |
-| U13 | Concurrent "move" (delete+insert) of the same list item. | The item is **duplicated**. | Known Yjs v13 limitation; documented list semantics (keyed encoding as a possible later module). |
+| U13 | Concurrent "move" (delete+insert) of the same list item. | The item is **duplicated**. | Known Yjs v13 limit; the keyed-map + order-field pattern avoids structural moves entirely (L9). |
 | U14 | One `doc.transact` spanning many nested types. | One `observeDeep` batch containing all events. | Remote changes apply as a single Elmish `Set` per transaction — atomic model updates. |
 | U15 | A client applies updates containing keys it doesn't understand. | Applied cleanly; unknown keys preserved and readable. | Forward compatibility is free *if we stop deleting unknown keys*. Foundation for schema migrations (the dual-key recipe). |
+| A1 | *(Adaptive, from L1 — to re-pin in Step 1)* What delta does Adaptify emit when a rebuilt `IndexList` replaces a field? | Positional: O(n) value-rewrites; nested adaptive objects rebound by position; reorder is never a move. | `Encode.list` = values only; identity lives in `HashMap` keys (`Encode.map`), whose Adaptify reconcile is keyed by construction. |
 
 ## Design
 
 ### Principles
 
-1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (future merge strategies, migration helpers) live in separate namespaces the consumer must `open`.
-2. **The codec is where merge behaviour is chosen.** A field's encoding *is* its merge policy: `Encode.text` means "concurrent edits interleave", `Encode.value` means "LWW register", `Encode.list` means "insert/delete merge". Nothing implicit.
+1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (ordering policies, richer merge strategies, migration helpers) live in consumer land or future opt-in namespaces, built on public seams.
+2. **The codec is where merge behaviour is chosen — the model's type is the merge choice** (L7). `Text` merges as text, `HashMap` merges element-wise by key, `IndexList` merges as a value sequence, a plain value is an LWW register, `atomic` is deliberate wholesale replacement, `custom` is yours. Nothing implicit.
 3. **Bind, never replace.** After init, the runtime only ever applies deltas to existing shared types. It never re-creates a container, never re-parents an instance (U5, U11).
 4. **Leave what you don't own.** The runtime never deletes keys it didn't encode (U15). Other clients and other schema versions co-exist by default.
-5. **Honest semantics, documented.** LWW tiebreak is deterministic-not-temporal (U4); reorders can duplicate (U13); delete beats edit-inside (U9). These go in the README, not in a footnote.
+5. **Honest semantics, documented.** LWW tiebreak is deterministic-not-temporal (U4); the offline first-create race is an app-design concern with a stated rule (U2a); delete beats edit-inside (U9); structural moves can duplicate (U13). These go in the README, not a footnote.
+6. **Dependency posture:** Elmish and Yjs are public vocabulary (Yjs deliberately so, in the escape hatch). Adaptive is plumbing — required today at `Create`/`Update` because of the Adaptify generator, kept out of every new public contract, and squeezed inward over time.
 
 ### Layer map
 
 ```
-public   ┌───────────────────────────────────────────────────────┐
-         │ Ylmish.Program.withYlmish        Elmish integration   │
-         │ Ylmish.Codec (Encode/Decode)     schema + merge policy│
-         │ Ylmish.Text                      mergeable text value │
-         ├───────────────────────────────────────────────────────┤
-internal │ Ylmish.Internal.Binding          encoded tree ↔ Y.Doc │
-         │ Ylmish.Internal.Y                attach/delta plumbing│
-         │ Fable.Yjs                        bindings (own pkg)   │
-         └───────────────────────────────────────────────────────┘
+public   ┌────────────────────────────────────────────────────────────┐
+         │ Ylmish.Program.withYlmish     Elmish integration           │
+         │ Ylmish.Codec (Encode/Decode)  schema + merge policy        │
+         │ Ylmish.Text                   mergeable text value         │
+         │ Ylmish.CustomElement          escape hatch (Yjs verbatim)  │
+         ├────────────────────────────────────────────────────────────┤
+internal │ Ylmish.Internal.Binding       encoded tree ↔ Y.Doc         │
+         │ Ylmish.Internal.Y             attach/delta plumbing        │
+         │ (FSharp.Data.Adaptive)        diff engine; public only at  │
+         │                               Adaptify Create/Update, and  │
+         │                               shrinking                    │
+         │ Fable.Yjs                     bindings (own pkg; public    │
+         │                               types resurface in the hatch)│
+         └────────────────────────────────────────────────────────────┘
 ```
-
-`Fable.Yjs` remains its own package (it is useful standalone), but Ylmish's contract is the top box only. Everything under `Ylmish.Internal` may change without notice.
 
 ### The consumer experience
 
-The target end-to-end feel, for a collaborative todo app:
+The target end-to-end feel, for a collaborative todo app. Note the shapes: todos are a `HashMap` keyed by an id the app mints at creation (which is also what makes offline creation safe, per the accepted-limitation rule), ordering is a plain LWW `Order` field, and no `aval` appears anywhere:
 
 ```fsharp
 open Ylmish
 
 [<ModelType>]
 type Todo = {
-    Title : Text          // collaborative: concurrent edits merge
-    Done  : bool          // register: last-writer-wins
+    Title : Text            // collaborative: concurrent edits merge
+    Done  : bool            // register: last-writer-wins
+    Order : string          // fractional index; LWW; consumer policy
 }
 
 [<ModelType>]
 type Model = {
-    Todos  : Todo IndexList
-    Filter : Filter        // app-only: not encoded, never persisted
+    Todos  : HashMap<string, Todo>   // keyed by app-minted id ⇒ element-wise merge
+    Filter : Filter                  // app-only: not encoded, never persisted
 }
 
 module Codec =
@@ -104,28 +129,30 @@ module Codec =
     let encodeTodo (t : AdaptiveTodo) = Encode.object [
         "title", Encode.text t.Title
         "done",  Encode.bool t.Done
+        "order", Encode.string t.Order
     ]
 
     let decodeTodo = Decode.object {
         let! title = Decode.object.required "title" Decode.text
         let! done_ = Decode.object.optional "done" Decode.bool
-        return { Title = title; Done = defaultArg done_ false }
+        let! order = Decode.object.optional "order" Decode.string
+        return { Title = title; Done = defaultArg done_ false; Order = defaultArg order "a0" }
     }
 
     let encode (m : AdaptiveModel) = Encode.object [
-        "todos", Encode.list encodeTodo m.Todos
+        "todos", Encode.map encodeTodo m.Todos
     ]
 
     let decode = Decode.object {
         let! model = Decode.ask                    // current model, for app-only fields
-        let! todos = Decode.object.optional "todos" (Decode.list.required decodeTodo)
-        return { model with Todos = defaultArg todos IndexList.empty }
+        let! todos = Decode.object.optional "todos" (Decode.map decodeTodo)
+        return { model with Todos = defaultArg todos HashMap.empty }
     }
 
 Program.mkProgram init update view
 |> Ylmish.Program.withYlmish {
     Doc    = doc
-    Create = AdaptiveModel.Create      // Adaptify-generated
+    Create = AdaptiveModel.Create      // Adaptify-generated (the one Adaptive seam)
     Update = AdaptiveModel.Update
     Encode = Codec.encode
     Decode = Codec.decode
@@ -136,10 +163,10 @@ Program.mkProgram init update view
 
 Notes on ergonomics:
 
-- The model stays a plain immutable record; the only Ylmish type that appears in it is `Text`.
-- `Decode.ask` (the Reader environment) is how app-only state survives remote updates: the decoder merges persisted fields into the *current* model.
-- `Decode.object.optional` + defaults is how "decode-empty = init" falls out naturally: an empty doc decodes to the init state through the same decoder as any other doc state. No separate seeding path exists.
-- Choosing merge behaviour per field is exactly one word: `Encode.text` vs `Encode.value`/`Encode.bool`/….
+- The model stays a plain immutable record; the only Ylmish type in it is `Text`.
+- `Decode.ask` (the Reader environment) is how app-only state survives remote updates.
+- `Decode.object.optional` + defaults is how "decode-empty = init" falls out naturally: an empty doc decodes to the init state through the same decoder as any other doc state.
+- Choosing merge behaviour per field is exactly one word: `Encode.text` vs `Encode.bool` vs `Encode.map` vs `Encode.atomic` vs `Encode.custom`.
 
 ### `Ylmish.Text`
 
@@ -157,108 +184,135 @@ module Text =
     val remove   : at:int -> count:int -> Text -> Text
     val replace  : at:int -> count:int -> string -> Text -> Text
     // convenience for plain <input>/<textarea> onChange, derives one splice
-    // by common prefix/suffix diff (ambiguous for repeats; documented)
+    // by common prefix/suffix diff (ambiguous for repeats; documented; the
+    // affix-diff strategy is validated minimal by L3)
     val edit     : newValue:string -> Text -> Text
 ```
 
 Semantics:
 
-- **Equality and comparison are by content only.** Pending intent is transport, not identity; `Text.ofString "hi" = (Text.empty |> Text.insert 0 "hi")`. Views and tests stay simple.
+- **Equality and comparison are by content only.** Pending intent is transport, not identity. Views and tests stay simple.
 - The runtime drains intents when flushing to the backing `Y.Text` and returns intent-free `Text` values on the way back in.
-- `Text.edit` exists so a bog-standard Elmish `OnChange (fun s -> dispatch (SetTitle s))` still produces splice-level merges; consumers wiring a real editor (CodeMirror, Monaco) can bypass ambiguity with `insert`/`remove`/`replace`, or (later, out of scope here) bind the editor straight to the underlying Y.Text.
+- Consumers wiring a real editor (CodeMirror, Monaco) who want the actual `Y.Text` bypass `Text` entirely via the `CustomElement` hatch.
 
 ### The codec, v2
 
-Two changes to `Ylmish.Adaptive.Codec` (which moves to `Ylmish.Codec`):
+The codec (moving to `Ylmish.Codec`) gains typed primitives (U10), a `Text` element kind, `atomic`, and `custom`. The taxonomy — **pick the model type that matches the merge you want** (L7):
 
-1. **Typed primitives.** `Element<'v>`'s value case becomes a proper primitive union (string/number/bool/null) mirroring what Y.Map actually stores (U10), so `Encode.bool`, `Encode.int`, `Encode.float` exist without stringly round-trips. `Encode.value : ('a -> Primitive) -> aval<'a> -> Encoded` remains the general register combinator.
-2. **A `Text` element kind.** `Element` gains `Text`, routed by the binding layer to a `Y.Text`. `Encode.text : AdaptiveText -> Encoded` and `Decode.text : Decoder<_, _, Text>` are the only new user-facing combinators.
-
-Everything else — `Encode.object/list/map/option`, the `Decode.object` builder, `required`/`optional`, `Decode.ask`, path-tracked validation errors — keeps its current shape. The codec grammar in full:
+| Model field | Combinator | Backed by | Concurrent behaviour |
+| --- | --- | --- | --- |
+| `Text` | `Encode.text` | `Y.Text` | splices interleave and merge |
+| `bool`/`int`/`float`/`string`/… | `Encode.bool`/… (`Encode.value` general) | map entry | LWW register (deterministic tiebreak) |
+| record | `Encode.object` | bound `Y.Map` | per-key merge of whatever each field chose (L8) |
+| `HashMap<string, 'T>` | `Encode.map` | `Y.Map` of bound entries | element-wise by key: different items never conflict; per-item fields merge per their own encodings; **the shape for anything creatable offline** |
+| `IndexList<'v>` (values only) | `Encode.list` | `Y.Array` | insert/delete merge, diff-reconciled by value; no text/custom inside items (L1 — runtime error pointing at `Encode.map`) |
+| any subtree | `Encode.atomic` | single wholesale value | deliberate whole-subtree LWW (L8) |
+| anything | `Encode.custom` | consumer-bound Y type | consumer-defined — see the escape hatch |
 
 ```
-Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key LWW of subtrees)
-           | list  encodeItem alist         → Y.Array   (insert/delete merge)
-           | map   encodeValue amap         → Y.Map     (per-key merge; the keyed-collection primitive)
-           | text  adaptiveText             → Y.Text    (splice merge)
-           | value toPrimitive aval         → primitive (LWW register)
+Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key merge)
+           | map    encodeItem amap         → Y.Map     (element-wise, keyed — the identity primitive)
+           | list   encodeValue alist       → Y.Array   (value sequence, diff-reconciled)
+           | text   adaptiveText            → Y.Text    (splice merge)
+           | value  toPrimitive aval        → primitive (LWW register)
+           | atomic Encoded                 → one value (wholesale LWW)
+           | custom CustomElement           → consumer-bound Y type
            | option …                       → presence/absence of any of the above
 ```
 
-`Encode.map` is deliberately first-class, not an afterthought: when a consumer's
-items have a stable key, a keyed Y.Map is the merge-friendly shape — concurrent
-edits to *different* items never conflict, and ordering can be modelled by the
-consumer as an explicit order field on each item (e.g. fractional indexing).
-Ylmish provides the primitive; the ordering policy stays in consumer land (a
-docs recipe shows the fractional-index pattern).
+Ordering of keyed items is the consumer's policy: an immutable key names the item, a mutable order field (e.g. fractional index) sorts it — never the reverse (L7). `recipes.md` shows the pattern.
+
+### `Ylmish.CustomElement` — the escape hatch
+
+For merge strategies core doesn't ship (counters, mergeable sets, timestamped LWW) **and** for handing a real Yjs type to something that wants one (a CodeMirror binding wants the `Y.Text` itself). The contract is deliberately Adaptive-free (design decision above; shape proven by L6):
+
+```fsharp
+type BindContext = {
+    /// Get-or-create this element's slot in the doc as a given Y type.
+    /// Real Fable.Yjs types, exposed on purpose. The binding layer guarantees
+    /// the instance is integrated exactly once (U5) and adopted, never replaced.
+    GetText  : unit -> Y.Text
+    GetMap   : unit -> Y.Map<obj>
+    GetArray : unit -> Y.Array<obj>
+    /// The origin token local writes must be transacted under (echo suppression, undo-readiness).
+    Origin   : obj
+}
+
+type CustomElement =
+    /// Wire the binding: push local model changes into the Y type, keep the
+    /// merged value current. Runs once at connect; dispose tears it down.
+    abstract Connect : BindContext -> System.IDisposable
+    /// Current merged value (read at decode time; boxed — Decode.custom unboxes
+    /// under the consumer's type).
+    abstract Value : obj
+```
+
+`Encode.custom : CustomElement -> Encoded` / `Decode.custom : Decoder<_,_,'a>`. No `Subscribe` member: under bind-in-place, remote changes to the custom's Y type surface through the same root `observeDeep` as everything else, so read-back needs no side channel (L4/L6 — this is the simplification their layout couldn't have). The canonical example (tests + demo + docs) is a grow-only counter whose concurrent increments **sum**; the docs also show the editor-binding scenario (`GetText` handed to a UI component, the field decoded read-only into the model).
 
 ### The runtime (internal): binding instead of materializing
 
 `Y.Doc.materialize`/`dematerialize` are deleted. In their place, an internal binding layer walks the encoded tree once and establishes live, bidirectional, delta-level bindings:
 
-- **Encode direction.** Adaptive deltas (from Adaptify's `Update` after each Elmish update) flow to the bound Y types inside a single `doc.transact` tagged with this instance's **origin token** (U6, U14). Containers that don't exist yet in the doc are created at the moment the first local edit touches them, within that same transaction (U2a). Existing containers are always adopted, never replaced (U5, U11). Keys the encoder doesn't mention are never touched (U15).
-- **Decode direction.** One `observeDeep` on the root; transactions carrying our own origin token are ignored (echo suppression); every other transaction produces exactly one decode → one Elmish `Set` dispatch (U7, U14). Decode failures go to `OnError` and leave the current model in place — a malformed or newer-versioned doc can't crash the loop.
+- **Encode direction.** Adaptive deltas flow to the bound Y types inside a single `doc.transact` tagged with this instance's **origin token** (U6, U14). All mutations happen inside `transact` — connect realizes the adaptive graph, so untransacted writes are a bug class, not a style choice (L4). Containers that don't exist yet are created at the moment the first local edit touches them, within that same transaction (U2a). Existing containers are adopted, never replaced (U5, U11); a kind mismatch between the encoded field and the existing Y type surfaces as a structured schema-drift error, not a Yjs internal throw (L5). Keys the encoder doesn't mention are never touched (U15). Lists are reconciled by value diff (minimal splices), maps element-wise by key.
+- **Decode direction.** One `observeDeep` on the root; transactions carrying our own origin token are ignored; every other transaction produces exactly one decode → one Elmish `Set` dispatch (U7, U14). Custom elements ride the same observer (L6). Decode failures go to `OnError` and leave the current model in place — a malformed or newer-versioned doc can't crash the loop.
 
-The existing `Text/Array/Map.attach` delta plumbing in `Y.fs` is the substance of this layer; it gets an origin-based guard instead of boolean flags, direction-split as the old TODO already called for, and moves under `Ylmish.Internal`.
+The existing `Text/Array/Map.attach` delta plumbing in `Y.fs` is the substance of this layer; it gets origin-based guards instead of boolean flags, direction-split as the old TODO already called for, and moves under `Ylmish.Internal`.
 
 ### Migrations: expressible, deferred
 
-**No Migrations module ships in this plan.** What *is* in scope is keeping migrations expressible with nothing but the public codec surface, so the module (if a real consumer ever justifies it) is ~20 lines of sugar rather than a runtime privilege:
+**No Migrations module ships in this plan.** What *is* in scope is keeping migrations expressible with nothing but the public codec surface:
 
 - Decoders compose, so "read old-or-new, prefer new" is an `oneOf`-shaped combinator over ordinary decoders.
 - Encoders produce key sets that can be merged, so "write both shapes during rollout" is a fold over ordinary encoders.
-- The load-bearing part is a **runtime rule**, and it is in scope: the binding layer never deletes keys it didn't encode (U15), so a v1 client and a v2 client can share a doc without destroying each other's representation.
+- The load-bearing part is a **runtime rule**, and it is in scope: the binding layer never deletes keys it didn't encode (U15).
 
-The dual-key rolling-upgrade recipe (v2 renames `"todos"` to `"items"`; write both, read either, drop the old leg when v1 clients are gone) becomes a documentation recipe, exercised by a compatibility test in Step 7 — not an API.
+The dual-key rolling-upgrade recipe becomes a documentation recipe, exercised by a compatibility test in Step 7 — not an API. (The executed branch built helpers and reverted them; deferral is validated.)
 
 ## Plan of work
 
-Each step is one PR-sized unit: it starts by writing failing (or characterization) tests, ends with `npm test` green, and leaves the library releasable. Later steps depend on earlier ones; nothing lands half-wired.
+Each step is one PR-sized unit: it starts by writing failing (or characterization) tests, ends with `npm test` green, and leaves the library releasable.
 
-### Step 1 — Pin the assumptions
+### Step 1 — Pin the assumptions (Yjs **and** Adaptive)
 
-Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` as characterization tests of Yjs itself (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), via the existing Fable.Yjs bindings.
+Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), and re-pin the Adaptify delta characterization (A1/L1: rebuild-regime positional rewrites; positional rebinding of nested adaptive objects; `HashMap` keyed reconcile) in `Adaptive.Assumptions.fs`.
 
-*Tests:* the table above, asserted. *Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs upgrade that changes semantics fails loudly.
+*Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs or Adaptify upgrade that changes semantics fails loudly.
 
-### Step 2 — North-star acceptance test (red)
+### Step 2 — Differential harness + north-star acceptance (red)
 
-The issue #83 test, written against the *target* public API and marked `ptestCase` (skipped): two `withYlmish` programs on separate docs; both edit the same `Text` field concurrently; updates exchanged via `encodeStateAsUpdate`/`applyUpdate`; both models converge to the same interleaved string. Plus a sibling test for "unknown keys survive a full session".
+Build the verification backbone modeled on the executed branch's harness (L2): a `Bridge` abstraction (whole immutable models in, converged model out — the `withYlmish` contract), a schedule-replay driver with delivery policies (Immediate/Concurrent), and a `differential` runner comparing the SUT against a raw-Yjs oracle. Calibrate it: green on the oracle, red on the current materialize path (the known #83 bug), green on the current path for sequential edits (it discriminates).
 
-*Acceptance:* compiles against the intended API surface (which forces the API sketch above to be written down as signatures), skipped in CI. Un-skipped in Step 7.
+Then write the north-star tests against the *target* public API, `ptestCase`-skipped: concurrent `Text` edits converge interleaved across two `withYlmish` programs; unknown keys survive a full session; keyed-map concurrent adds both survive.
+
+*Acceptance:* harness trustworthy by construction; north stars compile against the intended API signatures, skipped. Un-skipped in Step 7.
 
 ### Step 3 — `Ylmish.Text`
 
 Pure value type, no Yjs dependency.
 
-*Tests first:* content equality/hash laws; `insert`/`remove`/`replace` semantics incl. bounds; property — replaying any intent sequence over the old content equals the new content; property — `Text.edit` produces a single splice whose application equals the new string; Adaptify round-trip (`cval<Text>` works in a `[<ModelType>]`).
+*Tests first:* content equality/hash laws; `insert`/`remove`/`replace` semantics incl. bounds; property — replaying any intent sequence over the old content equals the new content; property — `Text.edit` produces a single minimal splice (affix diff, L3) whose application equals the new string; Adaptify round-trip (`cval<Text>` works in a `[<ModelType>]`).
 
-*Acceptance:* Text usable in a model today, even before sync exists (degrades to an ordinary value).
+*Acceptance:* `Text` usable in a model today, even before sync exists.
 
-### Step 4 — Codec v2: typed primitives + Text element
+### Step 4 — Codec v2: typed primitives, `text`, `atomic`, `custom`, keyed `map`
 
-*Tests first:* encode/decode round-trip properties for bool/int/float/string/null, `option`, nested objects/lists/maps, and `text`; error paths (`UnexpectedKind` when a register field meets a text decoder, etc.) with path reporting; `Decode.ask` merging app-only fields. Re-enable the two disabled roundtrip tests (#10/#12) or re-write them free of the Fable #3328 shape.
+*Tests first:* encode/decode round-trip properties for bool/int/float/string/null, `option`, nested objects, `map` (→ `HashMap`), `list` (values), `text`, `atomic` (round-trips as the inner codec), `custom` (element carries the binding; `Decode.custom` reads `Value`); error paths (`UnexpectedKind`, text/custom inside `Encode.list` items rejected per L1) with path reporting; `Decode.ask`. Re-enable or rewrite the two disabled roundtrip tests (#10/#12).
 
-*Acceptance:* codec fully specified with zero Yjs involvement — the schema layer is independently testable, per the layering principle.
+*Acceptance:* codec fully specified with zero Yjs runtime involvement (the `CustomElement` *type* references Fable.Yjs — that's the decided dependency posture).
 
 ### Step 5 — Binding layer, encode direction
 
-Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects, (b) keyed maps, (c) lists, (d) text, (e) nested composition.
+Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects — proving nested records merge per-field with no flattening machinery (L8); (b) keyed maps — element-wise reconcile, nested text under items, and the identity headline from their harness: **a keyed item's nested text survives concurrent membership changes and stays with its item** (L1/L7); (c) value lists — diff-reconciled minimal splices; (d) text; (e) atomic; (f) custom dispatch through `BindContext`; (g) composition.
 
-*Tests first (behavioural contract, two-doc where relevant):*
-- first local edit creates the container lazily, in one transaction (U2a discipline);
-- an existing container/Y.Text is adopted, never replaced — concurrent remote edits to it survive a local update (the U11 anti-test);
-- keys not mentioned by the encoder are untouched (U15);
-- update cost is O(delta): a 1-item change to a 1000-item list produces one Y op batch, asserted by counting `doc.on("update")` payload ops;
-- all writes carry the instance's origin token.
+*Tests first (behavioural contract, two-doc via the Step 2 harness where relevant):* lazy container creation in one transaction; adopt-never-replace (the U11 anti-test); untouched unknown keys; kind-drift structured error (L5); all writes transacted under the origin token (L4); O(delta) op counts via `doc.on("update")` for the keyed/list/text paths.
 
-*Acceptance:* `materialize` deleted; `Y.Doc` tests rewritten against `Binding`.
+*Acceptance:* `materialize` deleted; the harness's differential runner passes on every sub-step's slice where the old path failed.
 
 ### Step 6 — Binding layer, decode direction
 
-One `observeDeep` → route by event path → decode → dispatch.
+One `observeDeep` → decode → dispatch, custom elements riding the same observer.
 
-*Tests first:* own-origin transactions are ignored (no echo, no infinite loop — the current sentinel TODO closed properly); one remote transaction spanning many types yields exactly one `Set` (U14); remote text edits surface as intent-free `Text` values; a decode failure invokes `OnError`, keeps the current model, and the loop stays alive.
+*Tests first:* own-origin transactions ignored (no echo, no loop); one remote transaction spanning many types = exactly one `Set` (U14); remote text edits surface as intent-free `Text` values; remote custom edits surface through `Decode.custom` with no side channel (L6); decode failure invokes `OnError`, keeps the model, loop survives; the two imported crash regressions — a remote apply mid-flight never triggers a re-entrant local `Y.Text` write, and no adaptive mutation escapes `transact` (L4).
 
 *Acceptance:* full bidirectional binding at the adaptive layer, still without Elmish.
 
@@ -266,44 +320,63 @@ One `observeDeep` → route by event path → decode → dispatch.
 
 Rewire `Program.withYlmish` onto the binding layer; decode-empty-=-init on startup; delete the dead commented code in `Program.fs`.
 
-*Tests:* un-skip Step 2's north-star tests — they pass; the existing `Program.fs` test suite (fixing the known wrong assertions, e.g. `PropC`/`PropD`) passes; `TodoCollaborative` tests extended with the concurrent-edit case from issue #83's acceptance criteria; a **compatibility test** proving the dual-key migration recipe with plain combinators — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation.
+*Tests:* un-skip Step 2's north stars — they pass, including through the differential harness's `withYlmish` bridge; the existing `Program.fs` suite (fixing the known wrong assertions) passes; `TodoCollaborative` gains the concurrent-edit cases; the **compatibility test** proving the dual-key migration recipe with plain combinators — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation.
 
 *Acceptance:* issue #83 closed by tests, not by claim.
 
-### Step 8 — The demo
+### Step 8 — `CustomElement` escape hatch, proven end-to-end
 
-`examples/TodoCollaborative` stays a **CLI (Node) program**, rebuilt as a scripted narrative of the system under interesting concurrency. Two `withYlmish` programs on independent `Y.Doc`s, sync performed explicitly between acts, output printed per act:
+Public `Encode.custom`/`Decode.custom` + `BindContext` (Step 4 declared the types; this step proves them under `withYlmish`).
+
+*Tests first:* a consumer-authored grow-only counter **sums** concurrent increments across two `withYlmish` peers, converging in both Elmish models; the editor scenario — `GetText` hands out the live `Y.Text`, external edits to it flow into the model's decoded field; a custom binding cannot double-integrate its Y type (U5 guarded by `BindContext`).
+
+*Acceptance:* the hatch is sufficient to build a counter *without touching Ylmish internals or Adaptive* — the escape-hatch and encapsulation claims proven together.
+
+### Step 9 — Property-based stress
+
+Random two-replica add/remove/edit schedules over the keyed-map + text + register model, under Immediate and Concurrent delivery, replayed deterministically through the Step 2 harness: converged (P1), matches the raw-Yjs oracle (M1), no-loss where the oracle guarantees it (L2).
+
+*Acceptance:* ~100 schedules per policy, deterministic seeds, green in CI.
+
+### Step 10 — The demo
+
+`examples/TodoCollaborative` stays a **CLI (Node) program**, a scripted narrative of the system under interesting concurrency. Two `withYlmish` programs on independent `Y.Doc`s, sync performed explicitly between acts, output printed per act:
 
 1. Two peers start; neither seeds; both show init state (decode-empty = init, visibly).
-2. Offline: both edit the same note concurrently → sync → the interleaved merged text, side by side with what each peer typed.
-3. Offline: both insert todos concurrently → sync → both items survive in a deterministic order (list merge — required by the merge-menu decision).
-4. Both flip the same LWW register concurrently → sync → one deterministic winner, shown honestly as a clobber.
-5. One peer deletes an item while the other edits inside it → sync → delete wins.
-6. An app-only field changes throughout and never appears in either doc.
+2. Offline: both edit the same note concurrently → sync → the interleaved merged text.
+3. Offline: both *create* todos concurrently (app-minted ids, `Encode.map`) → sync → both items survive — the accepted-limitation rule demonstrated positively.
+4. Concurrent edits to *different fields of the same todo* → sync → both stick (per-field merge, L8).
+5. Both flip the same LWW register concurrently → sync → one deterministic winner, shown honestly as a clobber.
+6. One peer deletes a todo while the other edits inside it → sync → delete wins.
+7. Concurrent reorders via the fractional `Order` field → sync → converged order, no duplication (contrast with the documented structural-move limit).
+8. A consumer counter (the escape hatch) summing concurrent increments.
+9. An app-only field changes throughout and never appears in either doc.
 
-*Acceptance:* the demo exercises only the public API; `npm run demo` output reads as documentation, and the transcript is embedded in the README so a reader can falsify the library's claims in under a minute.
+*Acceptance:* the demo exercises only the public API; `npm run demo` output reads as documentation, and the transcript is embedded in the README.
 
-### Step 9 — Docs rewrite
+### Step 11 — Docs rewrite
 
-- **README:** keep the philosophy sections (they're good), replace the TODO list with: a 60-second quickstart mirroring the demo; a **merge semantics table** (field encoding → what happens on concurrent edits, including the honest limits: LWW tiebreak is deterministic-not-temporal, reorder duplication, delete-beats-edit-inside); the layer map with the public/internal line drawn explicitly; the demo transcript.
-- **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `text.md` (Text semantics, `edit` ambiguity, wiring editors), `recipes.md` (dual-key rolling migration with plain combinators; fractional-index ordering over `Encode.map`).
-- **AGENTS.md**: update layout/testing sections; mark plans 0001 (superseded where applicable) and 0002 statuses.
+- **README:** keep the philosophy sections; replace the TODO list with: a 60-second quickstart mirroring the demo; the **taxonomy table** ("the model's type is the merge choice") doubling as the merge-semantics table, with the honest limits (LWW tiebreak deterministic-not-temporal; the offline first-create rule — *anything creatable offline needs a unique key*; delete-beats-edit; structural-move duplication); the layer map with the public/internal line and the dependency posture (Yjs/Elmish public, Adaptive shrinking); the demo transcript.
+- **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `text.md` (Text semantics, `edit` ambiguity), `custom-elements.md` (writing a binding; the counter; wiring an editor to `GetText`), `recipes.md` (dual-key rolling migration; fractional-index ordering over `Encode.map`; modelling offline-creatable entities with app-minted keys).
+- **AGENTS.md**: update layout/testing sections (the harness becomes a documented testing tool); mark plans 0001 and 0002 statuses.
 
-*Acceptance:* every code sample in the docs is compiled (samples live in the demo or a doc-tests project, not in fenced blocks that rot).
+*Acceptance:* every code sample in the docs is compiled (samples live in the demo or a doc-tests project).
 
 ## Open questions
 
-Interface/behaviour details surfaced by the design — none blocking Steps 1–4:
+None blocking Steps 1–4:
 
 1. **`OnError` shape:** is "log and keep current model" the right decode-failure policy, or should consumers get the raw errors + the offending doc state to decide (e.g. surface "this doc was written by a newer client" UX)?
 2. **`Text` equality:** equality by content only (intent excluded) — acceptable? It makes `=`/memoization intuitive but means "has pending edits" is not observable via equality.
 3. **`Text.edit` ambiguity:** for repeated characters the single-splice diff can pick a different position than the user's actual edit (convergence unaffected; interleaving fidelity slightly coarser). Fine for the plain-`<input>` path given precise `insert`/`remove` exist?
 4. **Presence/awareness** (cursors, who's-online): explicitly out of scope for this plan, or wanted as a future optional module worth leaving API room for?
-5. **Undo:** `Y.UndoManager` integrates naturally with origin tokens (undo only your own origin's ops). Out of scope here, but should the binding layer's origin design reserve room for it (I propose: yes, it costs nothing)?
+5. **Undo:** `Y.UndoManager` integrates naturally with origin tokens (undo only your own origin's ops). Out of scope here, but the `BindContext.Origin` design deliberately reserves room for it.
+6. **`Encode.map` key types:** `string` keys only for v1 (Yjs map keys are strings); non-string keys would need a key codec. Acceptable to defer?
 
 ## Out of scope
 
 - Ycs/Yrs (.NET-native) backends — the old README TODO stands, unaffected.
-- Rich-text attributes/embeds in `Text` (Y.Text formatting) — plain text only for now.
+- Rich-text attributes/embeds in `Text` (Y.Text formatting) — plain text only; the escape hatch covers editors that need more.
 - Async resolution of decoded references (README TODO item on author IDs) — remains an app-layer concern via `Cmd`.
-- Provider integrations (y-websocket, y-indexeddb persistence) — the demo may use raw `applyUpdate` wiring; providers are the consumer's choice.
+- Provider integrations (y-websocket, y-indexeddb persistence) — the demo uses raw `applyUpdate` wiring; providers are the consumer's choice.
+- Ordering policies (fractional indexing) — consumer recipe, not library code (L7).

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -1,0 +1,323 @@
+# 0002 — Redesigning Ylmish around real CRDT merging
+
+Fixes [#83](https://github.com/NickDarvey/Ylmish/issues/83).
+
+## Motivation
+
+`Program.withYlmish` today synchronizes by **materializing the whole encoded state tree** into the Y.Doc on every Elmish update, and reading it back wholesale on every Y.Doc change. Consequences (all reproduced empirically, see [Validated assumptions](#validated-assumptions-about-yjs)):
+
+- String fields are atomic map values, so concurrent edits to the same field resolve last-writer-wins instead of merging. The canonical collaborative use case — two people typing in the same text body — silently loses one side's work.
+- Every update replaces nested `Y.Array`/`Y.Map`/`Y.Text` instances wholesale, which discards *any* concurrent remote edits inside them, not just text.
+- `materialize` deletes root keys it doesn't recognize, actively destroying data written by other clients or other schema versions — the exact opposite of what schema migration needs.
+- Re-materializing is O(state) per update rather than O(delta).
+
+Meanwhile the delta-level machinery that yields true CRDT convergence (`Text.attach`, `Array.attach`, `Map.attach` in `src/Ylmish/Y.fs`) already exists and passes its unit tests — it is simply unreachable from the codec and `withYlmish`.
+
+This plan replaces the materialize path with a **live binding**: the codec describes *which* shared type backs each field, and the runtime keeps the adaptive model and those shared types in sync by exchanging deltas, in both directions, forever.
+
+## Design inputs
+
+Decisions taken with Nick (2026-07-02):
+
+| Question | Decision |
+| --- | --- |
+| How does collaborative text appear in the consumer's model? | **A dedicated `Ylmish.Text` type** that carries edit intent, not a plain diffed `string`. |
+| Which layers are public? | **Elmish-first.** `Program.withYlmish` + the codec are the supported surface. The adaptive↔Y attach primitives stay internal so they can change freely. |
+| Who seeds a fresh document? | **Decode-empty = init.** The library never writes structure eagerly. An empty/partial doc decodes through the consumer's decoder (which has access to the current model); containers are created lazily by the first client that *edits* them, atomically. No seeding race by construction. |
+| Packaging | **One `Ylmish` package** (plus `Fable.Yjs`); opinionated extras are separate namespaces you must explicitly `open`. |
+
+Provisional decisions — recommended defaults, awaiting Nick's confirmation (see [Open questions](#open-questions)):
+
+| Question | Provisional |
+| --- | --- |
+| Per-field merge menu | Core codec offers **LWW registers + mergeable Text** (+ lists/maps). Richer strategies (counters, timestamped LWW, custom reduces) deferred until a consumer needs them. |
+| List semantics | **`Encode.list` → Y.Array with documented limits** (concurrent reorder duplicates; delete beats concurrent edit-inside). A keyed encoding can come later. |
+| Migrations scope | **Dual-key read/write combinators** (read old-or-new, prefer new, write both). No version bookkeeping in the doc. |
+| Demo form | **Two panes, one page**: two independent Elmish apps + Y.Docs on one static page with a connect/disconnect toggle. |
+
+## Validated assumptions about Yjs
+
+Runnable scripts: [`0002-assumptions/`](./0002-assumptions/) (`node experiments.mjs`, yjs 13.6.x). Step 1 of the plan pins these as characterization tests in CI.
+
+| # | Unknown | Result | Design consequence |
+| --- | --- | --- | --- |
+| U1 | What does argless `doc.getMap()` return? | The root map named `''`; same instance every call. | Root binding is stable; no need to force consumers to name a root map. |
+| U2a | Two clients each create a nested type under the same map key, then sync. | One client's **entire subtree wins**; the other's data is silently discarded. | Never create containers eagerly at init. Containers are created only on first local edit; decode of an empty doc yields the consumer's init state. |
+| U2b | Same race with *root-level* types (`doc.getArray "todos"`). | Merges by name; both sides' items survive. | Root types are safe to get-or-create. |
+| U3 | Concurrent edits to one shared nested `Y.Text`. | Interleave and converge. | The whole point. Text must bind to an existing instance, created once. |
+| U3b | Concurrent `map.set` of a plain string. | LWW clobber — issue #83's failure mode. | Plain values are honest LWW registers; the codec must let consumers choose text vs register per field. |
+| U4 | What decides the LWW winner? | Deterministic, order-independent: **higher clientID wins** among concurrent sets. Not wall-clock. | Document honestly: "last writer" is an arbitrary-but-convergent tiebreak. Timestamped LWW would be an opt-in module. |
+| U5 | Re-set an already-integrated Y type instance under another key. | **No exception at the call site; the doc corrupts** — later syncs throw and content is lost. | The public API must make re-parenting impossible by construction. The binding layer binds each model field to exactly one shared-type instance and never reuses instances. |
+| U6 | Do transaction origins propagate? | Yes: `doc.transact(fn, origin)` origins and `applyUpdate`'s origin both reach observers, with `local` flag. | Echo suppression via a per-binding origin token, replacing the current boolean-flag reentrancy guards. |
+| U7 | Does `observeDeep` on the root see nested edits? | Yes, typed events with paths (`["list", 0]`) and per-type deltas. | The decode direction can route remote deltas precisely. |
+| U8 | Concurrent Y.Array inserts at the same position. | Both survive, deterministic order. | Lists merge; safe default. |
+| U9 | Delete an item vs concurrent edit inside it. | Delete wins; the edit is lost. | Documented list semantics. |
+| U10 | What primitives can Y.Map hold? | Any JSON value (number, bool, null, string, plain objects/arrays). | The codec's `Element<string>` (strings only) is an unnecessary restriction; v2 elements carry typed primitives. |
+| U11 | Replace a nested Y.Text with a fresh one while a peer edits the old one. | Replacement wins; the peer's edits are lost. | Precisely why materialize-per-update can never merge. Bind, never replace. |
+| U13 | Concurrent "move" (delete+insert) of the same list item. | The item is **duplicated**. | Known Yjs v13 limitation; documented list semantics (keyed encoding as a possible later module). |
+| U14 | One `doc.transact` spanning many nested types. | One `observeDeep` batch containing all events. | Remote changes apply as a single Elmish `Set` per transaction — atomic model updates. |
+| U15 | A client applies updates containing keys it doesn't understand. | Applied cleanly; unknown keys preserved and readable. | Forward compatibility is free *if we stop deleting unknown keys*. Foundation for the Migrations module. |
+
+## Design
+
+### Principles
+
+1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (Migrations, future merge strategies) live in separate namespaces the consumer must `open`.
+2. **The codec is where merge behaviour is chosen.** A field's encoding *is* its merge policy: `Encode.text` means "concurrent edits interleave", `Encode.value` means "LWW register", `Encode.list` means "insert/delete merge". Nothing implicit.
+3. **Bind, never replace.** After init, the runtime only ever applies deltas to existing shared types. It never re-creates a container, never re-parents an instance (U5, U11).
+4. **Leave what you don't own.** The runtime never deletes keys it didn't encode (U15). Other clients and other schema versions co-exist by default.
+5. **Honest semantics, documented.** LWW tiebreak is deterministic-not-temporal (U4); reorders can duplicate (U13); delete beats edit-inside (U9). These go in the README, not in a footnote.
+
+### Layer map
+
+```
+public   ┌───────────────────────────────────────────────────────┐
+         │ Ylmish.Program.withYlmish        Elmish integration   │
+         │ Ylmish.Codec (Encode/Decode)     schema + merge policy│
+         │ Ylmish.Text                      mergeable text value │
+         │ Ylmish.Migrations (opt-in)       dual-key read/write  │
+         ├───────────────────────────────────────────────────────┤
+internal │ Ylmish.Internal.Binding          encoded tree ↔ Y.Doc │
+         │ Ylmish.Internal.Y                attach/delta plumbing│
+         │ Fable.Yjs                        bindings (own pkg)   │
+         └───────────────────────────────────────────────────────┘
+```
+
+`Fable.Yjs` remains its own package (it is useful standalone), but Ylmish's contract is the top box only. Everything under `Ylmish.Internal` may change without notice.
+
+### The consumer experience
+
+The target end-to-end feel, for a collaborative todo app:
+
+```fsharp
+open Ylmish
+
+[<ModelType>]
+type Todo = {
+    Title : Text          // collaborative: concurrent edits merge
+    Done  : bool          // register: last-writer-wins
+}
+
+[<ModelType>]
+type Model = {
+    Todos  : Todo IndexList
+    Filter : Filter        // app-only: not encoded, never persisted
+}
+
+module Codec =
+    open Ylmish.Codec
+
+    let encodeTodo (t : AdaptiveTodo) = Encode.object [
+        "title", Encode.text t.Title
+        "done",  Encode.bool t.Done
+    ]
+
+    let decodeTodo = Decode.object {
+        let! title = Decode.object.required "title" Decode.text
+        let! done_ = Decode.object.optional "done" Decode.bool
+        return { Title = title; Done = defaultArg done_ false }
+    }
+
+    let encode (m : AdaptiveModel) = Encode.object [
+        "todos", Encode.list encodeTodo m.Todos
+    ]
+
+    let decode = Decode.object {
+        let! model = Decode.ask                    // current model, for app-only fields
+        let! todos = Decode.object.optional "todos" (Decode.list.required decodeTodo)
+        return { model with Todos = defaultArg todos IndexList.empty }
+    }
+
+Program.mkProgram init update view
+|> Ylmish.Program.withYlmish {
+    Doc    = doc
+    Create = AdaptiveModel.Create      // Adaptify-generated
+    Update = AdaptiveModel.Update
+    Encode = Codec.encode
+    Decode = Codec.decode
+    OnError = Ylmish.Program.OnError.log
+}
+|> Program.run
+```
+
+Notes on ergonomics:
+
+- The model stays a plain immutable record; the only Ylmish type that appears in it is `Text`.
+- `Decode.ask` (the Reader environment) is how app-only state survives remote updates: the decoder merges persisted fields into the *current* model.
+- `Decode.object.optional` + defaults is how "decode-empty = init" falls out naturally: an empty doc decodes to the init state through the same decoder as any other doc state. No separate seeding path exists.
+- Choosing merge behaviour per field is exactly one word: `Encode.text` vs `Encode.value`/`Encode.bool`/….
+
+### `Ylmish.Text`
+
+An immutable value type representing collaboratively-edited text, carrying **edit intent** so the runtime can apply precise splices to the backing `Y.Text` (rather than guessing by diffing strings).
+
+```fsharp
+type Text                                   // opaque; content + pending intent
+module Text =
+    val empty    : Text
+    val ofString : string -> Text
+    val toString : Text -> string
+    val length   : Text -> int
+    // intent-carrying edits (what update functions use)
+    val insert   : at:int -> string -> Text -> Text
+    val remove   : at:int -> count:int -> Text -> Text
+    val replace  : at:int -> count:int -> string -> Text -> Text
+    // convenience for plain <input>/<textarea> onChange, derives one splice
+    // by common prefix/suffix diff (ambiguous for repeats; documented)
+    val edit     : newValue:string -> Text -> Text
+```
+
+Semantics:
+
+- **Equality and comparison are by content only.** Pending intent is transport, not identity; `Text.ofString "hi" = (Text.empty |> Text.insert 0 "hi")`. Views and tests stay simple.
+- The runtime drains intents when flushing to the backing `Y.Text` and returns intent-free `Text` values on the way back in.
+- `Text.edit` exists so a bog-standard Elmish `OnChange (fun s -> dispatch (SetTitle s))` still produces splice-level merges; consumers wiring a real editor (CodeMirror, Monaco) can bypass ambiguity with `insert`/`remove`/`replace`, or (later, out of scope here) bind the editor straight to the underlying Y.Text.
+
+### The codec, v2
+
+Two changes to `Ylmish.Adaptive.Codec` (which moves to `Ylmish.Codec`):
+
+1. **Typed primitives.** `Element<'v>`'s value case becomes a proper primitive union (string/number/bool/null) mirroring what Y.Map actually stores (U10), so `Encode.bool`, `Encode.int`, `Encode.float` exist without stringly round-trips. `Encode.value : ('a -> Primitive) -> aval<'a> -> Encoded` remains the general register combinator.
+2. **A `Text` element kind.** `Element` gains `Text`, routed by the binding layer to a `Y.Text`. `Encode.text : AdaptiveText -> Encoded` and `Decode.text : Decoder<_, _, Text>` are the only new user-facing combinators.
+
+Everything else — `Encode.object/list/map/option`, the `Decode.object` builder, `required`/`optional`, `Decode.ask`, path-tracked validation errors — keeps its current shape. The codec grammar in full:
+
+```
+Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key LWW of subtrees)
+           | list  encodeItem alist         → Y.Array   (insert/delete merge)
+           | map   encodeValue amap         → Y.Map     (per-key LWW)
+           | text  adaptiveText             → Y.Text    (splice merge)
+           | value toPrimitive aval         → primitive (LWW register)
+           | option …                       → presence/absence of any of the above
+```
+
+### The runtime (internal): binding instead of materializing
+
+`Y.Doc.materialize`/`dematerialize` are deleted. In their place, an internal binding layer walks the encoded tree once and establishes live, bidirectional, delta-level bindings:
+
+- **Encode direction.** Adaptive deltas (from Adaptify's `Update` after each Elmish update) flow to the bound Y types inside a single `doc.transact` tagged with this instance's **origin token** (U6, U14). Containers that don't exist yet in the doc are created at the moment the first local edit touches them, within that same transaction (U2a). Existing containers are always adopted, never replaced (U5, U11). Keys the encoder doesn't mention are never touched (U15).
+- **Decode direction.** One `observeDeep` on the root; transactions carrying our own origin token are ignored (echo suppression); every other transaction produces exactly one decode → one Elmish `Set` dispatch (U7, U14). Decode failures go to `OnError` and leave the current model in place — a malformed or newer-versioned doc can't crash the loop.
+
+The existing `Text/Array/Map.attach` delta plumbing in `Y.fs` is the substance of this layer; it gets an origin-based guard instead of boolean flags, direction-split as the old TODO already called for, and moves under `Ylmish.Internal`.
+
+### `Ylmish.Migrations` (opt-in module)
+
+Thin, compositional, built entirely from public codec combinators — which keeps it honest as a layer:
+
+```fsharp
+module Ylmish.Migrations
+
+// read: try decoders in order, first success wins
+val Decode.oneOf : Decoder<'m,'e,'r> list -> Decoder<'m,'e,'r>
+// write: run several encoders and merge their key sets (later wins on collision)
+val Encode.combine : Encoded list -> Encoded
+```
+
+Usage — rolling upgrade where v2 renames `"todos"` to `"items"` with a different item shape:
+
+```fsharp
+let decode = Decode.oneOf [ V2.decode; V1.decode |> Decoder.map Model.ofV1 ]
+let encode m = Encode.combine [ V2.encode m; V1.encode m ]   // write both, old clients keep working
+```
+
+The consumer decides when to drop the `V1` leg. No version keys, no doc rewriting, no magic. This works *only* because of the "leave what you don't own" runtime rule — a v1 client never deletes `"items"`, a v2 client never deletes `"todos"` (U15).
+
+## Plan of work
+
+Each step is one PR-sized unit: it starts by writing failing (or characterization) tests, ends with `npm test` green, and leaves the library releasable. Later steps depend on earlier ones; nothing lands half-wired.
+
+### Step 1 — Pin the assumptions
+
+Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` as characterization tests of Yjs itself (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), via the existing Fable.Yjs bindings.
+
+*Tests:* the table above, asserted. *Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs upgrade that changes semantics fails loudly.
+
+### Step 2 — North-star acceptance test (red)
+
+The issue #83 test, written against the *target* public API and marked `ptestCase` (skipped): two `withYlmish` programs on separate docs; both edit the same `Text` field concurrently; updates exchanged via `encodeStateAsUpdate`/`applyUpdate`; both models converge to the same interleaved string. Plus a sibling test for "unknown keys survive a full session".
+
+*Acceptance:* compiles against the intended API surface (which forces the API sketch above to be written down as signatures), skipped in CI. Un-skipped in Step 7.
+
+### Step 3 — `Ylmish.Text`
+
+Pure value type, no Yjs dependency.
+
+*Tests first:* content equality/hash laws; `insert`/`remove`/`replace` semantics incl. bounds; property — replaying any intent sequence over the old content equals the new content; property — `Text.edit` produces a single splice whose application equals the new string; Adaptify round-trip (`cval<Text>` works in a `[<ModelType>]`).
+
+*Acceptance:* Text usable in a model today, even before sync exists (degrades to an ordinary value).
+
+### Step 4 — Codec v2: typed primitives + Text element
+
+*Tests first:* encode/decode round-trip properties for bool/int/float/string/null, `option`, nested objects/lists/maps, and `text`; error paths (`UnexpectedKind` when a register field meets a text decoder, etc.) with path reporting; `Decode.ask` merging app-only fields. Re-enable the two disabled roundtrip tests (#10/#12) or re-write them free of the Fable #3328 shape.
+
+*Acceptance:* codec fully specified with zero Yjs involvement — the schema layer is independently testable, per the layering principle.
+
+### Step 5 — Binding layer, encode direction
+
+Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects, (b) lists, (c) text, (d) nested composition.
+
+*Tests first (behavioural contract, two-doc where relevant):*
+- first local edit creates the container lazily, in one transaction (U2a discipline);
+- an existing container/Y.Text is adopted, never replaced — concurrent remote edits to it survive a local update (the U11 anti-test);
+- keys not mentioned by the encoder are untouched (U15);
+- update cost is O(delta): a 1-item change to a 1000-item list produces one Y op batch, asserted by counting `doc.on("update")` payload ops;
+- all writes carry the instance's origin token.
+
+*Acceptance:* `materialize` deleted; `Y.Doc` tests rewritten against `Binding`.
+
+### Step 6 — Binding layer, decode direction
+
+One `observeDeep` → route by event path → decode → dispatch.
+
+*Tests first:* own-origin transactions are ignored (no echo, no infinite loop — the current sentinel TODO closed properly); one remote transaction spanning many types yields exactly one `Set` (U14); remote text edits surface as intent-free `Text` values; a decode failure invokes `OnError`, keeps the current model, and the loop stays alive.
+
+*Acceptance:* full bidirectional binding at the adaptive layer, still without Elmish.
+
+### Step 7 — `withYlmish` v2, end-to-end
+
+Rewire `Program.withYlmish` onto the binding layer; decode-empty-=-init on startup; delete the dead commented code in `Program.fs`.
+
+*Tests:* un-skip Step 2's north-star tests — they pass; the existing `Program.fs` test suite (fixing the known wrong assertions, e.g. `PropC`/`PropD`) passes; `TodoCollaborative` tests extended with the concurrent-edit case from issue #83's acceptance criteria.
+
+*Acceptance:* issue #83 closed by tests, not by claim.
+
+### Step 8 — `Ylmish.Migrations`
+
+*Tests first:* `Decode.oneOf` ordering and error accumulation; `Encode.combine` key-merge; the rolling-upgrade scenario — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation; a v2-only client reads a v1-only doc.
+
+*Acceptance:* module is pure sugar over public combinators (no runtime privileges) — proving the layering claim.
+
+### Step 9 — The demo
+
+`examples/TodoCollaborative` becomes a real browser app: one static page, two Elmish panes with independent `Y.Doc`s, a visible **connect/disconnect toggle** (severed = offline divergence; reconnect = watch CRDT convergence), a shared todo list with a collaboratively-edited note field, and an app-only field (e.g. filter) demonstrating what *doesn't* sync. Built with Vite, deployed to GitHub Pages by CI.
+
+*Acceptance:* the demo exercises only the public API; a reader can falsify the README's claims in the browser in under a minute.
+
+### Step 10 — Docs rewrite
+
+- **README:** keep the philosophy sections (they're good), replace the TODO list with: a 60-second quickstart mirroring the demo; a **merge semantics table** (field encoding → what happens on concurrent edits, including the honest limits: LWW tiebreak is deterministic-not-temporal, reorder duplication, delete-beats-edit-inside); the layer map with the public/internal line drawn explicitly; a link to the live demo.
+- **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `migrations.md` (dual-key pattern, when to drop the old leg), `text.md` (Text semantics, `edit` ambiguity, wiring editors).
+- **AGENTS.md**: update layout/testing sections; mark plans 0001 (superseded where applicable) and 0002 statuses.
+
+*Acceptance:* every code sample in the docs is compiled (samples live in the demo or a doc-tests project, not in fenced blocks that rot).
+
+## Open questions
+
+The provisional decisions above, plus a few new ones surfaced by the design — all interface/behaviour, none blocking Steps 1–4:
+
+1. **Merge menu** (Step 4 scope): core = LWW + Text only? Or also a general escape hatch (append-only event log + consumer-supplied reduce at decode — subsumes counters/max-wins), and/or opt-in modules for timestamped LWW and counters?
+2. **List semantics** (Step 5c): live with positional Y.Array limits (documented), or also ship a keyed encoding (items in Y.Map by stable ID + order field) for collaboratively-reordered lists?
+3. **Migrations scope** (Step 8): dual-key read/write as sketched, or versioned migration chains?
+4. **Demo form** (Step 9): two-pane static page as planned, real y-webrtc multiplayer, or the page with an optional webrtc flag?
+5. **`OnError` shape:** is "log and keep current model" the right decode-failure policy, or should consumers get the raw errors + the offending doc state to decide (e.g. surface "this doc was written by a newer client" UX)?
+6. **`Text` equality:** equality by content only (intent excluded) — acceptable? It makes `=`/memoization intuitive but means "has pending edits" is not observable via equality.
+7. **`Text.edit` ambiguity:** for repeated characters the single-splice diff can pick a different position than the user's actual edit (convergence unaffected; interleaving fidelity slightly coarser). Fine for the plain-`<input>` path given precise `insert`/`remove` exist?
+8. **Presence/awareness** (cursors, who's-online): explicitly out of scope for this plan, or wanted as a future optional module worth leaving API room for (e.g. the demo showing remote cursors in the note field)?
+9. **Undo:** `Y.UndoManager` integrates naturally with origin tokens (undo only your own origin's ops). Out of scope here, but should the binding layer's origin design reserve room for it (I propose: yes, it costs nothing)?
+
+## Out of scope
+
+- Ycs/Yrs (.NET-native) backends — the old README TODO stands, unaffected.
+- Rich-text attributes/embeds in `Text` (Y.Text formatting) — plain text only for now.
+- Async resolution of decoded references (README TODO item on author IDs) — remains an app-layer concern via `Cmd`.
+- Provider integrations (y-websocket, y-indexeddb persistence) — the demo may use raw `applyUpdate` wiring; providers are the consumer's choice.

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -25,15 +25,10 @@ Decisions taken with Nick (2026-07-02):
 | Which layers are public? | **Elmish-first.** `Program.withYlmish` + the codec are the supported surface. The adaptive↔Y attach primitives stay internal so they can change freely. |
 | Who seeds a fresh document? | **Decode-empty = init.** The library never writes structure eagerly. An empty/partial doc decodes through the consumer's decoder (which has access to the current model); containers are created lazily by the first client that *edits* them, atomically. No seeding race by construction. |
 | Packaging | **One `Ylmish` package** (plus `Fable.Yjs`); opinionated extras are separate namespaces you must explicitly `open`. |
-
-Provisional decisions — recommended defaults, awaiting Nick's confirmation (see [Open questions](#open-questions)):
-
-| Question | Provisional |
-| --- | --- |
-| Per-field merge menu | Core codec offers **LWW registers + mergeable Text** (+ lists/maps). Richer strategies (counters, timestamped LWW, custom reduces) deferred until a consumer needs them. |
-| List semantics | **`Encode.list` → Y.Array with documented limits** (concurrent reorder duplicates; delete beats concurrent edit-inside). A keyed encoding can come later. |
-| Migrations scope | **Dual-key read/write combinators** (read old-or-new, prefer new, write both). No version bookkeeping in the doc. |
-| Demo form | **Two panes, one page**: two independent Elmish apps + Y.Docs on one static page with a connect/disconnect toggle. |
+| Per-field merge menu | **LWW registers, mergeable Text, and mergeable lists (Y.Array insert/delete merge)** — the three merge behaviours Yjs gives us natively. Richer strategies (counters, timestamped LWW, custom reduces) deferred until a consumer needs them. The demo must exercise list merging, not just text. |
+| List semantics | **`Encode.list` → Y.Array with documented limits** (concurrent reorder duplicates; delete beats concurrent edit-inside). Additionally ship **`Encode.map` as the keyed primitive** (items in a Y.Map by consumer-supplied stable key) so consumers who have keys can build ordering themselves — e.g. fractional indexing as an order field. Ylmish provides the primitive, not the opinionated ordering machinery. |
+| Migrations | **Defer entirely.** No Migrations module yet. The codec must keep migrations *expressible* (decoders compose, encoders combine, the runtime preserves unknown keys) and the docs show the dual-key recipe, but nothing ships until a real consumer validates the need. |
+| Demo form | **CLI, as today.** A Node script whose output demonstrates the system under interesting concurrency: offline divergence, concurrent text edits interleaving, concurrent list inserts merging, LWW clobber shown honestly, reconvergence after sync. |
 
 ## Validated assumptions about Yjs
 
@@ -56,13 +51,13 @@ Runnable scripts: [`0002-assumptions/`](./0002-assumptions/) (`node experiments.
 | U11 | Replace a nested Y.Text with a fresh one while a peer edits the old one. | Replacement wins; the peer's edits are lost. | Precisely why materialize-per-update can never merge. Bind, never replace. |
 | U13 | Concurrent "move" (delete+insert) of the same list item. | The item is **duplicated**. | Known Yjs v13 limitation; documented list semantics (keyed encoding as a possible later module). |
 | U14 | One `doc.transact` spanning many nested types. | One `observeDeep` batch containing all events. | Remote changes apply as a single Elmish `Set` per transaction — atomic model updates. |
-| U15 | A client applies updates containing keys it doesn't understand. | Applied cleanly; unknown keys preserved and readable. | Forward compatibility is free *if we stop deleting unknown keys*. Foundation for the Migrations module. |
+| U15 | A client applies updates containing keys it doesn't understand. | Applied cleanly; unknown keys preserved and readable. | Forward compatibility is free *if we stop deleting unknown keys*. Foundation for schema migrations (the dual-key recipe). |
 
 ## Design
 
 ### Principles
 
-1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (Migrations, future merge strategies) live in separate namespaces the consumer must `open`.
+1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (future merge strategies, migration helpers) live in separate namespaces the consumer must `open`.
 2. **The codec is where merge behaviour is chosen.** A field's encoding *is* its merge policy: `Encode.text` means "concurrent edits interleave", `Encode.value` means "LWW register", `Encode.list` means "insert/delete merge". Nothing implicit.
 3. **Bind, never replace.** After init, the runtime only ever applies deltas to existing shared types. It never re-creates a container, never re-parents an instance (U5, U11).
 4. **Leave what you don't own.** The runtime never deletes keys it didn't encode (U15). Other clients and other schema versions co-exist by default.
@@ -75,7 +70,6 @@ public   ┌──────────────────────�
          │ Ylmish.Program.withYlmish        Elmish integration   │
          │ Ylmish.Codec (Encode/Decode)     schema + merge policy│
          │ Ylmish.Text                      mergeable text value │
-         │ Ylmish.Migrations (opt-in)       dual-key read/write  │
          ├───────────────────────────────────────────────────────┤
 internal │ Ylmish.Internal.Binding          encoded tree ↔ Y.Doc │
          │ Ylmish.Internal.Y                attach/delta plumbing│
@@ -185,11 +179,18 @@ Everything else — `Encode.object/list/map/option`, the `Decode.object` builder
 ```
 Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key LWW of subtrees)
            | list  encodeItem alist         → Y.Array   (insert/delete merge)
-           | map   encodeValue amap         → Y.Map     (per-key LWW)
+           | map   encodeValue amap         → Y.Map     (per-key merge; the keyed-collection primitive)
            | text  adaptiveText             → Y.Text    (splice merge)
            | value toPrimitive aval         → primitive (LWW register)
            | option …                       → presence/absence of any of the above
 ```
+
+`Encode.map` is deliberately first-class, not an afterthought: when a consumer's
+items have a stable key, a keyed Y.Map is the merge-friendly shape — concurrent
+edits to *different* items never conflict, and ordering can be modelled by the
+consumer as an explicit order field on each item (e.g. fractional indexing).
+Ylmish provides the primitive; the ordering policy stays in consumer land (a
+docs recipe shows the fractional-index pattern).
 
 ### The runtime (internal): binding instead of materializing
 
@@ -200,27 +201,15 @@ Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key LWW of subtre
 
 The existing `Text/Array/Map.attach` delta plumbing in `Y.fs` is the substance of this layer; it gets an origin-based guard instead of boolean flags, direction-split as the old TODO already called for, and moves under `Ylmish.Internal`.
 
-### `Ylmish.Migrations` (opt-in module)
+### Migrations: expressible, deferred
 
-Thin, compositional, built entirely from public codec combinators — which keeps it honest as a layer:
+**No Migrations module ships in this plan.** What *is* in scope is keeping migrations expressible with nothing but the public codec surface, so the module (if a real consumer ever justifies it) is ~20 lines of sugar rather than a runtime privilege:
 
-```fsharp
-module Ylmish.Migrations
+- Decoders compose, so "read old-or-new, prefer new" is an `oneOf`-shaped combinator over ordinary decoders.
+- Encoders produce key sets that can be merged, so "write both shapes during rollout" is a fold over ordinary encoders.
+- The load-bearing part is a **runtime rule**, and it is in scope: the binding layer never deletes keys it didn't encode (U15), so a v1 client and a v2 client can share a doc without destroying each other's representation.
 
-// read: try decoders in order, first success wins
-val Decode.oneOf : Decoder<'m,'e,'r> list -> Decoder<'m,'e,'r>
-// write: run several encoders and merge their key sets (later wins on collision)
-val Encode.combine : Encoded list -> Encoded
-```
-
-Usage — rolling upgrade where v2 renames `"todos"` to `"items"` with a different item shape:
-
-```fsharp
-let decode = Decode.oneOf [ V2.decode; V1.decode |> Decoder.map Model.ofV1 ]
-let encode m = Encode.combine [ V2.encode m; V1.encode m ]   // write both, old clients keep working
-```
-
-The consumer decides when to drop the `V1` leg. No version keys, no doc rewriting, no magic. This works *only* because of the "leave what you don't own" runtime rule — a v1 client never deletes `"items"`, a v2 client never deletes `"todos"` (U15).
+The dual-key rolling-upgrade recipe (v2 renames `"todos"` to `"items"`; write both, read either, drop the old leg when v1 clients are gone) becomes a documentation recipe, exercised by a compatibility test in Step 7 — not an API.
 
 ## Plan of work
 
@@ -254,7 +243,7 @@ Pure value type, no Yjs dependency.
 
 ### Step 5 — Binding layer, encode direction
 
-Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects, (b) lists, (c) text, (d) nested composition.
+Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects, (b) keyed maps, (c) lists, (d) text, (e) nested composition.
 
 *Tests first (behavioural contract, two-doc where relevant):*
 - first local edit creates the container lazily, in one transaction (U2a discipline);
@@ -277,43 +266,40 @@ One `observeDeep` → route by event path → decode → dispatch.
 
 Rewire `Program.withYlmish` onto the binding layer; decode-empty-=-init on startup; delete the dead commented code in `Program.fs`.
 
-*Tests:* un-skip Step 2's north-star tests — they pass; the existing `Program.fs` test suite (fixing the known wrong assertions, e.g. `PropC`/`PropD`) passes; `TodoCollaborative` tests extended with the concurrent-edit case from issue #83's acceptance criteria.
+*Tests:* un-skip Step 2's north-star tests — they pass; the existing `Program.fs` test suite (fixing the known wrong assertions, e.g. `PropC`/`PropD`) passes; `TodoCollaborative` tests extended with the concurrent-edit case from issue #83's acceptance criteria; a **compatibility test** proving the dual-key migration recipe with plain combinators — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation.
 
 *Acceptance:* issue #83 closed by tests, not by claim.
 
-### Step 8 — `Ylmish.Migrations`
+### Step 8 — The demo
 
-*Tests first:* `Decode.oneOf` ordering and error accumulation; `Encode.combine` key-merge; the rolling-upgrade scenario — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation; a v2-only client reads a v1-only doc.
+`examples/TodoCollaborative` stays a **CLI (Node) program**, rebuilt as a scripted narrative of the system under interesting concurrency. Two `withYlmish` programs on independent `Y.Doc`s, sync performed explicitly between acts, output printed per act:
 
-*Acceptance:* module is pure sugar over public combinators (no runtime privileges) — proving the layering claim.
+1. Two peers start; neither seeds; both show init state (decode-empty = init, visibly).
+2. Offline: both edit the same note concurrently → sync → the interleaved merged text, side by side with what each peer typed.
+3. Offline: both insert todos concurrently → sync → both items survive in a deterministic order (list merge — required by the merge-menu decision).
+4. Both flip the same LWW register concurrently → sync → one deterministic winner, shown honestly as a clobber.
+5. One peer deletes an item while the other edits inside it → sync → delete wins.
+6. An app-only field changes throughout and never appears in either doc.
 
-### Step 9 — The demo
+*Acceptance:* the demo exercises only the public API; `npm run demo` output reads as documentation, and the transcript is embedded in the README so a reader can falsify the library's claims in under a minute.
 
-`examples/TodoCollaborative` becomes a real browser app: one static page, two Elmish panes with independent `Y.Doc`s, a visible **connect/disconnect toggle** (severed = offline divergence; reconnect = watch CRDT convergence), a shared todo list with a collaboratively-edited note field, and an app-only field (e.g. filter) demonstrating what *doesn't* sync. Built with Vite, deployed to GitHub Pages by CI.
+### Step 9 — Docs rewrite
 
-*Acceptance:* the demo exercises only the public API; a reader can falsify the README's claims in the browser in under a minute.
-
-### Step 10 — Docs rewrite
-
-- **README:** keep the philosophy sections (they're good), replace the TODO list with: a 60-second quickstart mirroring the demo; a **merge semantics table** (field encoding → what happens on concurrent edits, including the honest limits: LWW tiebreak is deterministic-not-temporal, reorder duplication, delete-beats-edit-inside); the layer map with the public/internal line drawn explicitly; a link to the live demo.
-- **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `migrations.md` (dual-key pattern, when to drop the old leg), `text.md` (Text semantics, `edit` ambiguity, wiring editors).
+- **README:** keep the philosophy sections (they're good), replace the TODO list with: a 60-second quickstart mirroring the demo; a **merge semantics table** (field encoding → what happens on concurrent edits, including the honest limits: LWW tiebreak is deterministic-not-temporal, reorder duplication, delete-beats-edit-inside); the layer map with the public/internal line drawn explicitly; the demo transcript.
+- **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `text.md` (Text semantics, `edit` ambiguity, wiring editors), `recipes.md` (dual-key rolling migration with plain combinators; fractional-index ordering over `Encode.map`).
 - **AGENTS.md**: update layout/testing sections; mark plans 0001 (superseded where applicable) and 0002 statuses.
 
 *Acceptance:* every code sample in the docs is compiled (samples live in the demo or a doc-tests project, not in fenced blocks that rot).
 
 ## Open questions
 
-The provisional decisions above, plus a few new ones surfaced by the design — all interface/behaviour, none blocking Steps 1–4:
+Interface/behaviour details surfaced by the design — none blocking Steps 1–4:
 
-1. **Merge menu** (Step 4 scope): core = LWW + Text only? Or also a general escape hatch (append-only event log + consumer-supplied reduce at decode — subsumes counters/max-wins), and/or opt-in modules for timestamped LWW and counters?
-2. **List semantics** (Step 5c): live with positional Y.Array limits (documented), or also ship a keyed encoding (items in Y.Map by stable ID + order field) for collaboratively-reordered lists?
-3. **Migrations scope** (Step 8): dual-key read/write as sketched, or versioned migration chains?
-4. **Demo form** (Step 9): two-pane static page as planned, real y-webrtc multiplayer, or the page with an optional webrtc flag?
-5. **`OnError` shape:** is "log and keep current model" the right decode-failure policy, or should consumers get the raw errors + the offending doc state to decide (e.g. surface "this doc was written by a newer client" UX)?
-6. **`Text` equality:** equality by content only (intent excluded) — acceptable? It makes `=`/memoization intuitive but means "has pending edits" is not observable via equality.
-7. **`Text.edit` ambiguity:** for repeated characters the single-splice diff can pick a different position than the user's actual edit (convergence unaffected; interleaving fidelity slightly coarser). Fine for the plain-`<input>` path given precise `insert`/`remove` exist?
-8. **Presence/awareness** (cursors, who's-online): explicitly out of scope for this plan, or wanted as a future optional module worth leaving API room for (e.g. the demo showing remote cursors in the note field)?
-9. **Undo:** `Y.UndoManager` integrates naturally with origin tokens (undo only your own origin's ops). Out of scope here, but should the binding layer's origin design reserve room for it (I propose: yes, it costs nothing)?
+1. **`OnError` shape:** is "log and keep current model" the right decode-failure policy, or should consumers get the raw errors + the offending doc state to decide (e.g. surface "this doc was written by a newer client" UX)?
+2. **`Text` equality:** equality by content only (intent excluded) — acceptable? It makes `=`/memoization intuitive but means "has pending edits" is not observable via equality.
+3. **`Text.edit` ambiguity:** for repeated characters the single-splice diff can pick a different position than the user's actual edit (convergence unaffected; interleaving fidelity slightly coarser). Fine for the plain-`<input>` path given precise `insert`/`remove` exist?
+4. **Presence/awareness** (cursors, who's-online): explicitly out of scope for this plan, or wanted as a future optional module worth leaving API room for?
+5. **Undo:** `Y.UndoManager` integrates naturally with origin tokens (undo only your own origin's ops). Out of scope here, but should the binding layer's origin design reserve room for it (I propose: yes, it costs nothing)?
 
 ## Out of scope
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -38,7 +38,7 @@ That branch executed its own plans 0002–0009 to close #83 by accretion (flatte
 | # | Lesson (their evidence) | Consequence in this plan |
 | --- | --- | --- |
 | L1 | **Adaptify list deltas are positional, not keyed** (their 0006 Step 1, pinned in `Adaptive.Spike.fs`). The idiomatic rebuild `{ m with Items = recompute() }` yields O(n) positional value-rewrites, and `ChangeableModelList` **rebinds nested adaptive objects by position** — a nested `Y.Text` hung off item *i* gets hijacked by whatever lands at position *i*. | `Encode.list` is restricted to value sequences **by its type**: it accepts only `Value.Encoder<'a>` from the primitive sub-language, so text/custom/object items are unrepresentable rather than runtime-rejected. Step 1 re-pins this characterization in our suite. The plan's O(delta) claims are scoped: lists are diff-reconciled by value, maps are keyed by construction (`HashMap` → keyed `amap` reconcile, their 0008 Step 0a). |
-| L2 | **Differential testing against a raw-Yjs oracle** (their 0006 harness): replay per-replica schedules under a delivery policy, compare the full bridge against hand-written Yjs, plus property-based random schedules. It caught the whole-container-LWW bug red-handed and *discriminated* (green on sequential). | Adopted as this plan's verification backbone (Steps 2 and 9). No self-authored spec to be wrong about. |
+| L2 | **Differential testing against a raw-Yjs oracle** (their 0006 harness): replay per-replica schedules under a delivery policy, compare the full bridge against hand-written Yjs, plus property-based random schedules. It caught the whole-container-LWW bug red-handed and *discriminated* (green on sequential). | Adopted as this plan's verification backbone (Steps 2a and 9). No self-authored spec to be wrong about. |
 | L3 | **Common-affix diff produces minimal text deltas** (their A5: one char change = 2 ops, not clear+reinsert; Myers unnecessary). | Validates `Text.edit`'s implementation strategy and the "plain `<input>` stays cheap" claim. |
 | L4 | **Read-back fragmentation was a consequence of their layout.** Flattening leaves to separate roots meant root-map `observeDeep` never saw remote text/custom edits → per-clist observers → merged read-back trees → `afterTransaction` hooks, with real crashes en route (re-entrant `Y.Text` edit during a remote apply; `"cannot mark object without transaction"`). | Bind-in-place keeps **one** `observeDeep` (nested events reach the root, U7) and origin tokens suppress echo (U6) — structurally avoiding that bug class. Their two crashes become named regression tests in Step 6. Their lesson that connect realizes the adaptive graph (all mutations must be inside `transact`) is folded into Step 5's contract. |
 | L5 | **Root kind drift throws** (their A2): re-getting a root under a different type is an error, and schema drift needs a clear message. | The binding layer detects kind mismatch (encoded kind vs existing Y type) and surfaces a structured decode/bind error rather than a Yjs internal throw. Step 5 test. |
@@ -293,43 +293,109 @@ The dual-key rolling-upgrade recipe becomes a documentation recipe, exercised by
 
 ## Plan of work
 
-Each step is one PR-sized unit: it starts by writing failing (or characterization) tests, ends with `npm test` green, and leaves the library releasable.
+Each step is one PR-sized unit: it starts by writing failing (or characterization) tests, ends with `npm test` green, and leaves the library releasable. Sub-steps within a step are individually committable green increments.
+
+### Working the plan
+
+For the engineer executing this (competent F#, new to this codebase):
+
+- **Setup.** `npm install && npm test` must be green before Step 1 (see `AGENTS.md`; tests run via Fable→Mocha — `dotnet test` will not work). Record the passing count: it is your baseline number, and every check-in reports the new one.
+- **Reference quarry.** Branch `claude/github-issues-visibility-8k12g3` executed a *different* architecture for this same issue, but much of its **test code transfers**: `tests/Ylmish.Tests/Y.Assumptions.fs` and `Adaptive.Spike.fs` (Step 1), `Harness.fs`/`Harness.Options.fs`/`Harness.Stress.fs` (Steps 2a, 9), and its `Codec.*.fs` tests as scenario inspiration. Crib freely and adapt; do **not** import its `Scheme`/flattening design, its boolean reentrancy guards, or its `materialize` hybrid — those are exactly what this plan replaces.
+- **Interim-compatibility rule (Steps 4–6).** The old `materialize`/`dematerialize` path stays alive until Step 7 — `withYlmish` runs on it until then and the suite must stay green at every step boundary. When Step 4 adds `Element` cases, the old path handles them with a descriptive `failwith` ("Text/Atomic/Custom fields require the binding runtime; see plan 0002 Step 7") — never silently skipping. Deleting the old path is Step 7's job, not yours early.
+- **Cadence.** One commit per green increment. Never commit red. If a step's premise turns out wrong mid-flight, stop and check in — this plan encodes decisions that are Nick's to change, and improvising around a broken premise is how the reference branch accreted three naming conventions.
+- **Check-in ritual (after every step, before the next):** tick the step in *Progress* below and bump the test count; add a short *Decisions & lessons* note under the step recording anything surprising or anything you had to interpret (interpretation is a design decision in disguise — surface it); show the diff, the names of the new tests, and the runnable output where a step has one (harness calibration, demo acts).
+
+### Progress
+
+- [ ] Step 0 — Baseline (S)
+- [ ] Step 1 — Pin the assumptions (M)
+- [ ] Step 2a — Differential harness (M)
+- [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
+- [ ] Step 3 — `Ylmish.Text` (M)
+- [ ] Step 4 — Codec v2 (L; sub-steps 4a–4e)
+- [ ] Step 5 — Binding, encode direction (L; sub-steps 5a–5g)
+- [ ] Step 6 — Binding, decode direction (M)
+- [ ] Step 7 — `withYlmish` v2; old path dies (M)
+- [ ] Step 8 — `CustomElement` end-to-end (M)
+- [ ] Step 9 — Property stress (S)
+- [ ] Step 10 — Demo (M)
+- [ ] Step 11 — Docs (M)
+
+### Step 0 — Baseline
+
+No code changes. Get the toolchain running per `AGENTS.md`, run `npm test`, record the passing/skipped counts in *Progress*, and skim `src/Ylmish/Y.fs`, `Adaptive.Codec.fs`, `Program.fs` plus this plan's *Validated assumptions* table.
+
+*Check-in:* baseline test count; anything already broken on your machine; questions about the plan itself before work starts.
 
 ### Step 1 — Pin the assumptions (Yjs **and** Adaptive)
 
-Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), and re-pin the Adaptify delta characterization (A1/L1: rebuild-regime positional rewrites; positional rebinding of nested adaptive objects; `HashMap` keyed reconcile) in `Adaptive.Assumptions.fs`.
+Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), and re-pin the Adaptify delta characterization (A1/L1: rebuild-regime positional rewrites; positional rebinding of nested adaptive objects; `HashMap` keyed reconcile) in `Adaptive.Assumptions.fs`. The reference branch has working versions of both files to adapt.
 
 *Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs or Adaptify upgrade that changes semantics fails loudly.
 
-### Step 2 — Differential harness + north-star acceptance (red)
+*Check-in:* test count; a one-line map from each assumption id (U*/A1) to its test name; any assumption that did **not** reproduce (that's a stop-the-line finding — it invalidates part of the design).
 
-Build the verification backbone modeled on the executed branch's harness (L2): a `Bridge` abstraction (whole immutable models in, converged model out — the `withYlmish` contract), a schedule-replay driver with delivery policies (Immediate/Concurrent), and a `differential` runner comparing the SUT against a raw-Yjs oracle. Calibrate it: green on the oracle, red on the current materialize path (the known #83 bug), green on the current path for sequential edits (it discriminates).
+### Step 2a — Differential harness
 
-Then write the north-star tests against the *target* public API, `ptestCase`-skipped: concurrent `Text` edits converge interleaved across two `withYlmish` programs; unknown keys survive a full session; keyed-map concurrent adds both survive.
+Build the verification backbone modeled on the reference branch's `Harness.fs` (L2): a `Bridge` abstraction (whole immutable models in, converged model out — the `withYlmish` contract), a schedule-replay driver with delivery policies (Immediate/Concurrent), and a `differential` runner comparing the system-under-test against a raw-Yjs oracle (the same schedule hand-applied to plain Y types). Keep it minimal: two replicas, one model shape, deterministic replay.
 
-*Acceptance:* harness trustworthy by construction; north stars compile against the intended API signatures, skipped. Un-skipped in Step 7.
+Calibrate it — this is the step's real deliverable: **green on the oracle** (ground truth holds), **red on the current materialize path** (it catches the known #83 bug and names the lost data), **green on the current path for sequential edits** (it discriminates rather than failing everything).
+
+*Acceptance:* the three calibration results above, as committed tests (the materialize-red one marked as expected-fail/pending so the suite stays green).
+
+*Check-in:* test count; the calibration triad's output; the harness's public surface (it will be reused in Steps 5, 7, 9).
+
+### Step 2b — Target API skeleton + north stars (red) — **design-review checkpoint**
+
+Transcribe this plan's API sketches into compiling F# signatures with stub bodies: `Ylmish.Text` (module + type), `Ylmish.Codec` (`Value` sub-language, `Encode.*`/`Decode.*` including `map`/`text`/`atomic`/`custom`), `CustomElement`/`BindContext`, and the `withYlmish` options record. Stubs `failwith "plan 0002: not implemented until Step N"`.
+
+Then write the north-star tests against that surface, `ptestCase`-skipped: concurrent `Text` edits converge interleaved across two `withYlmish` programs; unknown keys survive a full session; keyed-map concurrent adds both survive.
+
+*Acceptance:* everything compiles; north stars are skipped; **no implementation**.
+
+*Check-in:* this is the one to slow down on — the diff *is* the public API. Nick reviews the signatures here, before any implementation exists to defend. Surface every place the sketches in this document were ambiguous and what you chose.
 
 ### Step 3 — `Ylmish.Text`
 
-Pure value type, no Yjs dependency.
+Pure value type, no Yjs dependency. Replace the Step 2b stubs with the real implementation.
 
 *Tests first:* content equality/hash laws; `insert`/`remove`/`replace` semantics incl. bounds; property — replaying any intent sequence over the old content equals the new content; property — `Text.edit` produces a single minimal splice (affix diff, L3) whose application equals the new string; Adaptify round-trip (`cval<Text>` works in a `[<ModelType>]`).
 
 *Acceptance:* `Text` usable in a model today, even before sync exists.
 
+*Check-in:* test count; the property-test generators (they get reused); confirmation the Adaptify round-trip works (this is the step most likely to surface a generator limitation — if `cval<Text>` doesn't survive `[<ModelType>]`, stop and check in, because it forces a design change).
+
 ### Step 4 — Codec v2: typed primitives, `text`, `atomic`, `custom`, keyed `map`
 
-*Tests first:* encode/decode round-trip properties for the `Value` sub-language (bool/int/float/string, `contramap`/`map` for domain types), `option`, nested objects, `map` (→ `HashMap`), `list` (`Value` items), `text`, `atomic` (round-trips as the inner codec), `custom` (element carries the binding; `Decode.custom` reads `Value`); error paths (`UnexpectedKind`) with path reporting; `Decode.ask`. The L1 restriction is enforced by types, so it isn't a runtime test — a should-not-compile snippet in the docs/tests records that `Encode.list` cannot accept text/custom/object items. Re-enable or rewrite the two disabled roundtrip tests (#10/#12).
+Sub-steps, each a green commit. Remember the **interim-compatibility rule**: the old materialize path stubs the new `Element` cases with a descriptive `failwith`; existing tests must stay green after every sub-step.
 
-*Acceptance:* codec fully specified with zero Yjs runtime involvement (the `CustomElement` *type* references Fable.Yjs — that's the decided dependency posture).
+- **4a — `Value` sub-language.** Purely additive: `Value.Encoder`/`Value.Decoder`, the four primitives, `contramap`/`map`. Round-trip properties, including a domain type over `contramap`.
+- **4b — `Element` v2.** Reshape the union: typed primitive payloads (U10), `Text`, `Atomic`, `Custom` cases. This is the sub-step that ripples — fix every exhaustive match, applying the interim rule in the old path. No new behaviour yet.
+- **4c — registers, objects, lists over `Value`.** `Encode.value/bool/int/float/string`, `Encode.list`/`Decode.list` taking `Value.*`; the should-not-compile snippet recording that `Encode.list` cannot accept text/custom/object items (the L1 restriction is type-level, so it isn't a runtime test).
+- **4d — `map`, `text`, `atomic`.** `Encode.map`/`Decode.map` (→ `HashMap`), `Encode.text`/`Decode.text` over `Ylmish.Text`, `Encode.atomic`/`Decode.atomic` (round-trips as the inner codec).
+- **4e — `custom` + housekeeping.** `Encode.custom`/`Decode.custom` (element carries the binding; decode reads `Value`); error paths (`UnexpectedKind`) with path reporting; `Decode.ask`; re-enable or rewrite the two disabled roundtrip tests (#10/#12).
+
+*Acceptance:* codec fully specified with zero Yjs runtime involvement (the `CustomElement` *type* references Fable.Yjs — that's the decided dependency posture); old suite still green via the interim rule.
+
+*Check-in:* test count per sub-step; which exhaustive matches 4b touched and how; status of #10/#12 (fixed, rewritten, or still blocked — say which and why).
 
 ### Step 5 — Binding layer, encode direction
 
-Internal `Binding.attach doc encoded : IDisposable`, replacing `materialize`. Sub-steps, each red-green: (a) registers + objects — proving nested records merge per-field with no flattening machinery (L8); (b) keyed maps — element-wise reconcile, nested text under items, and the identity headline from their harness: **a keyed item's nested text survives concurrent membership changes and stays with its item** (L1/L7); (c) value lists — diff-reconciled minimal splices; (d) text; (e) atomic; (f) custom dispatch through `BindContext`; (g) composition.
+Internal `Binding.attach doc encoded : IDisposable` — the eventual replacement for `materialize`, built **alongside** it (`withYlmish` keeps running on the old path until Step 7; nothing is deleted here). Sub-steps, each red-green:
 
-*Tests first (behavioural contract, two-doc via the Step 2 harness where relevant):* lazy container creation in one transaction; adopt-never-replace (the U11 anti-test); untouched unknown keys; kind-drift structured error (L5); all writes transacted under the origin token (L4); O(delta) op counts via `doc.on("update")` for the keyed/list/text paths.
+- **5a** — registers + objects: proving nested records merge per-field with no flattening machinery (L8);
+- **5b** — keyed maps: element-wise reconcile, nested text under items, and the identity headline from the reference harness — **a keyed item's nested text survives concurrent membership changes and stays with its item** (L1/L7);
+- **5c** — value lists: diff-reconciled minimal splices;
+- **5d** — text;
+- **5e** — atomic;
+- **5f** — custom dispatch through `BindContext`;
+- **5g** — composition (a model using every kind at once).
 
-*Acceptance:* `materialize` deleted; the harness's differential runner passes on every sub-step's slice where the old path failed.
+*Tests first (behavioural contract, two-doc via the Step 2a harness where relevant):* lazy container creation in one transaction; adopt-never-replace (the U11 anti-test); untouched unknown keys; kind-drift structured error (L5); all writes transacted under the origin token (L4); O(delta) op counts via `doc.on("update")` for the keyed/list/text paths.
+
+*Acceptance:* the harness's differential runner passes on every sub-step's slice **where the old materialize path failed its calibration** — same schedules, new result; old path untouched and old suite green.
+
+*Check-in:* test count per sub-step; the differential runner's before/after on the #83 calibration schedule; any place the binding had to deviate from the design section (say what and why).
 
 ### Step 6 — Binding layer, decode direction
 
@@ -339,27 +405,35 @@ One `observeDeep` → decode → dispatch, custom elements riding the same obser
 
 *Acceptance:* full bidirectional binding at the adaptive layer, still without Elmish.
 
+*Check-in:* test count; a trace of one remote transaction → one `Set` (the U14 batching evidence); confirmation both imported crash regressions are covered by name.
+
 ### Step 7 — `withYlmish` v2, end-to-end
 
-Rewire `Program.withYlmish` onto the binding layer; decode-empty-=-init on startup; delete the dead commented code in `Program.fs`.
+Rewire `Program.withYlmish` onto the binding layer; decode-empty-=-init on startup. **This is where the old world dies:** delete `materialize`/`dematerialize`, the interim `failwith` stubs from Step 4b, and the dead commented code in `Program.fs`.
 
-*Tests:* un-skip Step 2's north stars — they pass, including through the differential harness's `withYlmish` bridge; the existing `Program.fs` suite (fixing the known wrong assertions) passes; `TodoCollaborative` gains the concurrent-edit cases; the **compatibility test** proving the dual-key migration recipe with plain combinators — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation.
+*Tests:* un-skip Step 2b's north stars — they pass, including through the differential harness's `withYlmish` bridge; the existing `Program.fs` suite (fixing the known wrong assertions, e.g. `PropC`/`PropD`) passes rewritten against the binding path; `TodoCollaborative` gains the concurrent-edit cases; the **compatibility test** proving the dual-key migration recipe with plain combinators — a v1-schema program and a v2-schema program share a doc, edit concurrently, and neither destroys the other's representation.
 
-*Acceptance:* issue #83 closed by tests, not by claim.
+*Acceptance:* issue #83 closed by tests, not by claim; zero references to `materialize` remain.
+
+*Check-in:* test count; the north stars' names now green; what the old-path deletion removed (line count is a feature here); any `Program.fs` test whose assertion you had to change and the reasoning.
 
 ### Step 8 — `CustomElement` escape hatch, proven end-to-end
 
-Public `Encode.custom`/`Decode.custom` + `BindContext` (Step 4 declared the types; this step proves them under `withYlmish`).
+Prove the hatch under `withYlmish` (the types exist since 2b/4e; the dispatch since 5f; the readback since 6 — this step is consumer-side proof, not new runtime machinery).
 
 *Tests first:* a consumer-authored grow-only counter **sums** concurrent increments across two `withYlmish` peers, converging in both Elmish models; the editor scenario — `GetText` hands out the live `Y.Text`, external edits to it flow into the model's decoded field; a custom binding cannot double-integrate its Y type (U5 guarded by `BindContext`).
 
 *Acceptance:* the hatch is sufficient to build a counter *without touching Ylmish internals or Adaptive* — the escape-hatch and encapsulation claims proven together.
 
+*Check-in:* test count; the counter's full source (its size and its `open` list are the measure of the hatch's ergonomics — bring both).
+
 ### Step 9 — Property-based stress
 
-Random two-replica add/remove/edit schedules over the keyed-map + text + register model, under Immediate and Concurrent delivery, replayed deterministically through the Step 2 harness: converged (P1), matches the raw-Yjs oracle (M1), no-loss where the oracle guarantees it (L2).
+Random two-replica add/remove/edit schedules over the keyed-map + text + register model, under Immediate and Concurrent delivery, replayed deterministically through the Step 2a harness. Invariants, per schedule: the replicas **converge** to equal models, the converged state **matches the raw-Yjs oracle**, and nothing the oracle preserves was lost (L2).
 
 *Acceptance:* ~100 schedules per policy, deterministic seeds, green in CI.
+
+*Check-in:* test count; runtime cost of the stress suite (if it dominates CI, propose a split: small always-on set + larger nightly/manual set — that's a check-in decision, not yours alone).
 
 ### Step 10 — The demo
 
@@ -377,13 +451,17 @@ Random two-replica add/remove/edit schedules over the keyed-map + text + registe
 
 *Acceptance:* the demo exercises only the public API; `npm run demo` output reads as documentation, and the transcript is embedded in the README.
 
+*Check-in:* the transcript itself — read it as a stranger; each act should be intelligible without having read this plan.
+
 ### Step 11 — Docs rewrite
 
 - **README:** keep the philosophy sections; replace the TODO list with: a 60-second quickstart mirroring the demo; the **taxonomy table** ("the model's type is the merge choice") doubling as the merge-semantics table, with the honest limits (LWW tiebreak deterministic-not-temporal; the offline first-create rule — *anything creatable offline needs a unique key*; delete-beats-edit; structural-move duplication); the layer map with the public/internal line and the dependency posture (Yjs/Elmish public, Adaptive shrinking); the demo transcript.
 - **doc/guides/**: `codec.md` (schema decoupling, `Decode.ask`, app-only state), `text.md` (Text semantics, `edit` ambiguity), `custom-elements.md` (writing a binding; the counter; wiring an editor to `GetText`), `recipes.md` (dual-key rolling migration; fractional-index ordering over `Encode.map`; modelling offline-creatable entities with app-minted keys).
 - **AGENTS.md**: update layout/testing sections (the harness becomes a documented testing tool); mark plans 0001 and 0002 statuses.
 
-*Acceptance:* every code sample in the docs is compiled (samples live in the demo or a doc-tests project).
+*Acceptance:* every code sample in the docs is compiled — concretely: each sample is a verbatim excerpt of code that lives in `examples/` or `tests/` (marked with a comment naming the doc that quotes it), so CI compiles them by construction; no free-floating fenced code that can rot.
+
+*Check-in:* final test count vs the Step 0 baseline; the README read top-to-bottom; the list of plan Open questions that remain open (they carry forward, not silently expire).
 
 ## Open questions
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -27,7 +27,7 @@ Decisions taken with Nick:
 | The nested first-create race (U2a) | **Accepted as a documented limitation, solved by application design.** If two offline peers each *first-create* the same nested container and later sync, one subtree wins wholesale. The app-level rule: anything that can be *created* offline needs a consumer-supplied unique key (`Encode.map` keyed by it), so independent offline creations occupy distinct keys and never race. Editing an *existing* field offline is the normal CRDT case and merges. The library documents this rule; it does not contort the document layout to dissolve the race. |
 | Packaging | **One `Ylmish` package** (plus `Fable.Yjs`); opinionated extras are separate namespaces you must explicitly `open`. |
 | Per-field merge menu | **LWW registers, mergeable Text, mergeable lists (Y.Array), keyed element-wise maps** — plus **`Encode.atomic`** (deliberate wholesale-LWW subtree) and **`Encode.custom`** (the `CustomElement` escape hatch for consumer-defined merge strategies and direct Y-type access). Opinionated strategies built *on* the hatch (counters, timestamped LWW) stay out of core. The demo must exercise list and keyed-map merging, not just text. |
-| List semantics | **`Encode.list` is for value sequences** (insert/delete merge, diff-reconciled). **Records with identity go in `Encode.map`** over `HashMap<key, _>` — this is now a hard rule, not a preference, because Adaptify's list deltas are positional (see L1) and would corrupt nested collaborative state under insert/reorder. Ordering of keyed items is the consumer's concern (fractional-index recipe in docs). |
+| List semantics | **`Encode.list` is for value sequences** (insert/delete merge, diff-reconciled). **Records with identity go in `Encode.map`** over `HashMap<key, _>` — this is now a hard rule, not a preference, because Adaptify's list deltas are positional (see L1) and would corrupt nested collaborative state under insert/reorder. The rule is **enforced by construction, not at runtime**: `Encode.list` accepts only the explicit `Value` primitive sub-language (an opaque `Value.Encoder<'a>`), so a text/custom/object item does not typecheck. Ordering of keyed items is the consumer's concern (fractional-index recipe in docs). |
 | Migrations | **Defer entirely.** No Migrations module. The codec keeps migrations *expressible* (decoders compose, encoders combine, the runtime preserves unknown keys) and the docs show the dual-key recipe. (The executed branch independently built migration helpers and then cut them — treat that as confirmation.) |
 | Demo form | **CLI.** A Node script whose output demonstrates the system under interesting concurrency: offline divergence, text interleaving, list merges, keyed-map merges, an honest LWW clobber, reconvergence. |
 
@@ -37,7 +37,7 @@ That branch executed its own plans 0002–0009 to close #83 by accretion (flatte
 
 | # | Lesson (their evidence) | Consequence in this plan |
 | --- | --- | --- |
-| L1 | **Adaptify list deltas are positional, not keyed** (their 0006 Step 1, pinned in `Adaptive.Spike.fs`). The idiomatic rebuild `{ m with Items = recompute() }` yields O(n) positional value-rewrites, and `ChangeableModelList` **rebinds nested adaptive objects by position** — a nested `Y.Text` hung off item *i* gets hijacked by whatever lands at position *i*. | `Encode.list` is restricted to value sequences; items may not contain text/custom leaves (runtime error pointing at `Encode.map`). Step 1 re-pins this characterization in our suite. The plan's O(delta) claims are scoped: lists are diff-reconciled by value, maps are keyed by construction (`HashMap` → keyed `amap` reconcile, their 0008 Step 0a). |
+| L1 | **Adaptify list deltas are positional, not keyed** (their 0006 Step 1, pinned in `Adaptive.Spike.fs`). The idiomatic rebuild `{ m with Items = recompute() }` yields O(n) positional value-rewrites, and `ChangeableModelList` **rebinds nested adaptive objects by position** — a nested `Y.Text` hung off item *i* gets hijacked by whatever lands at position *i*. | `Encode.list` is restricted to value sequences **by its type**: it accepts only `Value.Encoder<'a>` from the primitive sub-language, so text/custom/object items are unrepresentable rather than runtime-rejected. Step 1 re-pins this characterization in our suite. The plan's O(delta) claims are scoped: lists are diff-reconciled by value, maps are keyed by construction (`HashMap` → keyed `amap` reconcile, their 0008 Step 0a). |
 | L2 | **Differential testing against a raw-Yjs oracle** (their 0006 harness): replay per-replica schedules under a delivery policy, compare the full bridge against hand-written Yjs, plus property-based random schedules. It caught the whole-container-LWW bug red-handed and *discriminated* (green on sequential). | Adopted as this plan's verification backbone (Steps 2 and 9). No self-authored spec to be wrong about. |
 | L3 | **Common-affix diff produces minimal text deltas** (their A5: one char change = 2 ops, not clear+reinsert; Myers unnecessary). | Validates `Text.edit`'s implementation strategy and the "plain `<input>` stays cheap" claim. |
 | L4 | **Read-back fragmentation was a consequence of their layout.** Flattening leaves to separate roots meant root-map `observeDeep` never saw remote text/custom edits → per-clist observers → merged read-back trees → `afterTransaction` hooks, with real crashes en route (re-entrant `Y.Text` edit during a remote apply; `"cannot mark object without transaction"`). | Bind-in-place keeps **one** `observeDeep` (nested events reach the root, U7) and origin tokens suppress echo (U6) — structurally avoiding that bug class. Their two crashes become named regression tests in Step 6. Their lesson that connect realizes the adaptive graph (all mutations must be inside `transact`) is folded into Step 5's contract. |
@@ -78,7 +78,7 @@ Runnable scripts: [`0002-assumptions/`](./0002-assumptions/) (`node experiments.
 ### Principles
 
 1. **Layered, opt-in, no all-or-nothing.** Core stays small; opinions (ordering policies, richer merge strategies, migration helpers) live in consumer land or future opt-in namespaces, built on public seams.
-2. **The codec is where merge behaviour is chosen — the model's type is the merge choice** (L7). `Text` merges as text, `HashMap` merges element-wise by key, `IndexList` merges as a value sequence, a plain value is an LWW register, `atomic` is deliberate wholesale replacement, `custom` is yours. Nothing implicit.
+2. **The codec is where merge behaviour is chosen — the model's type is the merge choice** (L7). `Text` merges as text, `HashMap` merges element-wise by key, `IndexList` merges as a value sequence, a plain value is an LWW register, `atomic` is deliberate wholesale replacement, `custom` is yours. Nothing implicit — and **illegal encodings are unrepresentable, not runtime-checked**: positions with restricted vocabularies (list items, registers) take their own narrower encoder types.
 3. **Bind, never replace.** After init, the runtime only ever applies deltas to existing shared types. It never re-creates a container, never re-parents an instance (U5, U11).
 4. **Leave what you don't own.** The runtime never deletes keys it didn't encode (U15). Other clients and other schema versions co-exist by default.
 5. **Honest semantics, documented.** LWW tiebreak is deterministic-not-temporal (U4); the offline first-create race is an app-design concern with a stated rule (U2a); delete beats edit-inside (U9); structural moves can duplicate (U13). These go in the README, not a footnote.
@@ -205,19 +205,42 @@ The codec (moving to `Ylmish.Codec`) gains typed primitives (U10), a `Text` elem
 | `bool`/`int`/`float`/`string`/… | `Encode.bool`/… (`Encode.value` general) | map entry | LWW register (deterministic tiebreak) |
 | record | `Encode.object` | bound `Y.Map` | per-key merge of whatever each field chose (L8) |
 | `HashMap<string, 'T>` | `Encode.map` | `Y.Map` of bound entries | element-wise by key: different items never conflict; per-item fields merge per their own encodings; **the shape for anything creatable offline** |
-| `IndexList<'v>` (values only) | `Encode.list` | `Y.Array` | insert/delete merge, diff-reconciled by value; no text/custom inside items (L1 — runtime error pointing at `Encode.map`) |
+| `IndexList<'v>` (values only) | `Encode.list` | `Y.Array` | insert/delete merge, diff-reconciled by value; items are `Value` primitives *by construction* (L1) — entities belong in `Encode.map` |
 | any subtree | `Encode.atomic` | single wholesale value | deliberate whole-subtree LWW (L8) |
 | anything | `Encode.custom` | consumer-bound Y type | consumer-defined — see the escape hatch |
 
 ```
 Encoded  ::= object [(key, Encoded)]        → Y.Map     (per-key merge)
            | map    encodeItem amap         → Y.Map     (element-wise, keyed — the identity primitive)
-           | list   encodeValue alist       → Y.Array   (value sequence, diff-reconciled)
+           | list   Value.Encoder alist     → Y.Array   (value sequence, diff-reconciled)
            | text   adaptiveText            → Y.Text    (splice merge)
-           | value  toPrimitive aval        → primitive (LWW register)
+           | value  Value.Encoder aval      → primitive (LWW register)
            | atomic Encoded                 → one value (wholesale LWW)
            | custom CustomElement           → consumer-bound Y type
            | option …                       → presence/absence of any of the above
+```
+
+**The `Value` sub-language — incorrect by construction.** Positions that can only hold JSON primitives (list items, registers) do not take an arbitrary `Encoded`; they take an opaque `Value.Encoder<'a>`, constructible *only* from an explicitly enumerated set of primitives. There is no injection from `Encoded` into `Value.Encoder`, so "a list of texts" or "a list of objects" is not a runtime error — it is a type error at the call site, and the fix (`Encode.map`) is visible in the signature you reach for instead.
+
+```fsharp
+module Ylmish.Codec.Value
+
+type Encoder<'a>        // opaque: 'a → JSON primitive
+type Decoder<'a>        // opaque: JSON primitive → 'a, with path-tracked errors
+
+val string : Encoder<string>          val int    : Encoder<int>
+val float  : Encoder<float>           val bool   : Encoder<bool>
+// domain types ride a primitive by mapping, staying inside the sub-language:
+val contramap : ('b -> 'a) -> Encoder<'a> -> Encoder<'b>   // e.g. TodoId → string
+val map       : ('a -> 'b) -> Decoder<'a> -> Decoder<'b>
+```
+
+The register combinators are then sugar over the same sub-language (`Encode.bool = Encode.value Value.bool`), and the codec has exactly one notion of "primitive" shared by registers and list items:
+
+```fsharp
+val Encode.value : Value.Encoder<'a> -> aval<'a>  -> Encoded
+val Encode.list  : Value.Encoder<'a> -> alist<'a> -> Encoded
+val Decode.list  : Value.Decoder<'a> -> Decoder<_, _, IndexList<'a>>
 ```
 
 Ordering of keyed items is the consumer's policy: an immutable key names the item, a mutable order field (e.g. fractional index) sorts it — never the reverse (L7). `recipes.md` shows the pattern.
@@ -296,7 +319,7 @@ Pure value type, no Yjs dependency.
 
 ### Step 4 — Codec v2: typed primitives, `text`, `atomic`, `custom`, keyed `map`
 
-*Tests first:* encode/decode round-trip properties for bool/int/float/string/null, `option`, nested objects, `map` (→ `HashMap`), `list` (values), `text`, `atomic` (round-trips as the inner codec), `custom` (element carries the binding; `Decode.custom` reads `Value`); error paths (`UnexpectedKind`, text/custom inside `Encode.list` items rejected per L1) with path reporting; `Decode.ask`. Re-enable or rewrite the two disabled roundtrip tests (#10/#12).
+*Tests first:* encode/decode round-trip properties for the `Value` sub-language (bool/int/float/string, `contramap`/`map` for domain types), `option`, nested objects, `map` (→ `HashMap`), `list` (`Value` items), `text`, `atomic` (round-trips as the inner codec), `custom` (element carries the binding; `Decode.custom` reads `Value`); error paths (`UnexpectedKind`) with path reporting; `Decode.ask`. The L1 restriction is enforced by types, so it isn't a runtime test — a should-not-compile snippet in the docs/tests records that `Encode.list` cannot accept text/custom/object items. Re-enable or rewrite the two disabled roundtrip tests (#10/#12).
 
 *Acceptance:* codec fully specified with zero Yjs runtime involvement (the `CustomElement` *type* references Fable.Yjs — that's the decided dependency posture).
 


### PR DESCRIPTION
## Summary

This PR adds a comprehensive design plan (0002) for redesigning Ylmish to use real CRDT merging instead of the current materialize-per-update approach. It includes detailed design documentation, validated assumptions about Yjs behavior, and a roadmap for implementation.

## Changes

- **`doc/plans/0002-ylmish-redesign.md`** (483 lines): Complete design plan covering:
  - Motivation: Current materialize approach loses concurrent edits, discards remote changes, and is O(state) per update
  - Design inputs: Key decisions on text representation, public API layers, merge strategies, and packaging
  - Lessons from prior branch execution: Adaptive list delta semantics, differential testing approach, custom element contracts
  - Validated assumptions: 15 Yjs behavior experiments (U1–U15) and 1 Adaptive behavior (A1) with design consequences
  - Detailed design principles: Layered architecture, codec-driven merge choice, bind-never-replace semantics, honest error handling
  - Layer map: Public surface (Program.withYlmish, Codec, Text, CustomElement) vs internal binding/Y plumbing
  - Consumer experience: Example collaborative todo app showing plain immutable records with Text fields
  - Codec v2 taxonomy: Text (splice merge), value types (LWW), objects (per-key merge), maps (element-wise keyed), lists (value sequences), atomic (wholesale LWW), custom (escape hatch)
  - CustomElement contract: Adaptive-free BindContext and Value for consumer-defined merge strategies
  - Runtime binding layer: Delta-level bidirectional sync replacing materialize, with origin-based echo suppression
  - Migration strategy: Expressible via codec composition without a dedicated Migrations module

- **`doc/plans/0002-assumptions/experiments.mjs`** (247 lines): Runnable Yjs experiments validating assumptions U1–U12:
  - Root map identity and initialization races
  - Concurrent text editing and plain-string LWW clobber
  - LWW winner determination (clientID-based, deterministic)
  - Type re-parenting corruption
  - Transaction origin propagation
  - observeDeep nested event delivery
  - Array insert merging and delete-beats-edit semantics
  - Primitive type support in Y.Map

- **`doc/plans/0002-assumptions/experiments2.mjs`** (83 lines): Additional Yjs experiments for U5b/U5c, U13–U15:
  - Cross-document type reuse failures
  - Concurrent move duplication
  - Single-transaction batching of observeDeep events
  - Forward compatibility with unknown keys

- **`doc/plans/0002-assumptions/README.md`** (20 lines): Instructions for running the assumption experiments and their role in pinning Yjs semantics

## Notable Details

- The plan explicitly documents accepted limitations (offline first-create race, delete-beats-edit, move duplication) rather than trying to engineer them away
- The `Value` sub-language makes illegal encodings (e.g., list of objects) unrepresentable at the type level rather than runtime-checked
- The binding layer uses origin tokens for echo suppression instead of boolean reentrancy flags, aligning with Yjs's UndoManager expectations
- CustomElement contract is deliberately Adaptive-free to keep the public surface clean while the internal binding layer handles adaptive deltas
- The plan defers migrations entirely but keeps them expressible through codec composition and the runtime's preservation of unknown keys

https://claude.ai/code/session_013RKxgiTophokAKjqMX2toS