### PR TITLE
Pin Yjs assumptions as characterization tests (plan 0002 Step 1)

### DIFF
--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -308,7 +308,7 @@ For the engineer executing this (competent F#, new to this codebase):
 ### Progress
 
 - [x] Step 0 — Baseline (S) — 99 passing, 0 skipped
-- [x] Step 1 — Pin the assumptions (M) — 124 passing (+16 Y.Assumptions, +9 Adaptive.Assumptions)
+- [x] Step 1 — Pin the assumptions (M) — 125 passing (+16 Y.Assumptions, +10 Adaptive.Assumptions)
 - [ ] Step 2a — Differential harness (M)
 - [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
 - [ ] Step 3 — `Ylmish.Text` (M)
@@ -327,7 +327,7 @@ No code changes. Get the toolchain running per `AGENTS.md`, run `npm test`, reco
 
 *Check-in:* baseline test count; anything already broken on your machine; questions about the plan itself before work starts.
 
-*Decisions & lessons (executed 2026-07-04):* baseline 99 passing, 0 skipped, nothing broken. (PR #123 "establish test baseline" merged with an empty diff, so the count is recorded here instead.)
+*Decisions & lessons (executed 2026-07-04):* baseline 99 passing, 0 skipped, nothing broken. (PR #123 "establish test baseline" merged with an empty diff, so the count is recorded here instead.) Toolchain note (from the parallel Step 0 runs, PRs #125/#127): fresh environments ship without a .NET SDK, so `npm install` fails at `dotnet restore` — install SDK 10.0.300 per `global.json` via `dotnet-install.sh` first. One benign pre-existing restore warning (`NU1608`: `YoloDev.Expecto.TestSdk 0.13.3` wants `Expecto < 10`, `10.2.3` resolves) — tests pass regardless.
 
 ### Step 1 — Pin the assumptions (Yjs **and** Adaptive)
 
@@ -339,11 +339,14 @@ Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs`
 
 *Decisions & lessons (executed 2026-07-04):*
 
-- Every assumption reproduced exactly as tabled — no stop-the-line findings. Assumption → test map (all in `Y.Assumptions.fs` under the same-named `testList`): U1 root map identity, U2a nested first-create race, U2b root-level create race, U3 shared nested Y.Text, U3b plain-string map value, U4 LWW tiebreak, U5b re-parenting an integrated type, U6 transaction origins, U7 observeDeep coverage, U8 concurrent array inserts, U9 delete vs edit-inside, U10 typed primitives in Y.Map, U11 replace vs concurrent edit, U13 concurrent structural move, U14 transaction batching, U15 unknown keys. A1/L1 in `Adaptive.Assumptions.fs`: three IndexList structural-op tests (minimal deltas), rebuild + reorder positional-rewrite tests, positional nested rebinding, and three HashMap keyed-reconcile tests (O(delta) ops; identity follows the key). Ported beyond the plan's minimum: U1, U3b, U7, U8, U10 (cheap, and each backs a design claim). Not ported: U5 (subsumed by U5b), U12 (subsumed by U2a).
+- Every assumption reproduced exactly as tabled — no stop-the-line findings. Assumption → test map (all in `Y.Assumptions.fs` under the same-named `testList`): U1 root map identity, U2a nested first-create race, U2b root-level create race, U3 shared nested Y.Text, U3b plain-string map value, U4 LWW tiebreak, U5b re-parenting an integrated type, U6 transaction origins, U7 observeDeep coverage, U8 concurrent array inserts, U9 delete vs edit-inside, U10 typed primitives in Y.Map, U11 replace vs concurrent edit, U13 concurrent structural move, U14 transaction batching, U15 unknown keys. A1/L1 in `Adaptive.Assumptions.fs`: three IndexList structural-op tests (minimal deltas), rebuild + reorder positional-rewrite tests, positional nested rebinding, and four HashMap keyed-reconcile tests (O(delta) ops on add/remove; zero outer ops on value-update; identity follows the key). Ported beyond the plan's minimum: U1, U3b, U7, U8, U10 (cheap, and each backs a design claim). Not ported: U5 (subsumed by U5b), U12 (subsumed by U2a).
 - The HashMap keyed-reconcile characterization needed a model with a `HashMap` field; added `MapModel` to the test common's `Example.fs` (Adaptify generates a keyed `ChangeableModelMap` for it, confirming the L1 contrast by construction).
-- Interpretation: U7's path-tracked events (`["list", 0]`) are pinned as *coverage* (event counts through one deep observer), not paths — the Fable.Yjs `YEvent` binding doesn't expose `path`. The binding gap is real and Step 6 (decode direction) will need `path` bound; noting rather than fixing here since Step 1 adds no production code.
+- Interpretation: U7's path-tracked events (`["list", 0]`) are pinned as *coverage* (event counts through one deep observer) plus **target identity** (the nested text's deep event carries the `Y.Text` instance itself, by reference — grafted from #127's approach), not paths — the Fable.Yjs `YEvent` binding doesn't expose `path`. The binding gap is real and Step 6 (decode direction) will need `path` bound; noting rather than fixing here since Step 1 adds no production code.
 - Fable interop gotcha: an F# `int[]` compiles to a JS `Int32Array`, which Yjs rejects with "Unexpected content type" — U10 pins plain (boxed) arrays. Worth remembering for the codec's list encoding.
+- Fable interop gotcha #2 (grafted from #127): a stored JS `null` is a real Y.Map value, but the binding's `YMap.get : string -> 'T option` collapses it to `None` — **indistinguishable from a missing key**. U10 pins null presence via `has`. Design consequence for Step 4: `Encode.option` must model absence via key presence, never via null through `get`.
 - U5b makes Yjs log an internal `TypeError` to the console mid-suite; expected noise, documented in the test.
+- Post-review hardening (review on PR #126): U2a, U3b and U8 now pin their exact deterministic outcomes (survivor `["from-d2"]`; winner `"oh, hello"`; converged order `["from-d1"; "from-d2"; "base"]`) instead of disjunctions/sorted membership — a flipped tiebreak now fails loudly. Added the keyed **value-update** delta characterization (editing an existing key's value = 0 outer amap ops, absorbed by the nested adaptive object in place) — the case Step 5b's O(delta) claims lean on hardest.
+- Inventory for Step 7 (grafted from #127's skim): `Program.fs` carries ~330 lines of commented-out prior codec sketches below the live `withYlmish` — part of Step 7's deletion.
 
 ### Step 2a — Differential harness
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -307,8 +307,8 @@ For the engineer executing this (competent F#, new to this codebase):
 
 ### Progress
 
-- [ ] Step 0 — Baseline (S)
-- [ ] Step 1 — Pin the assumptions (M)
+- [x] Step 0 — Baseline (S) — 99 passing, 0 skipped
+- [x] Step 1 — Pin the assumptions (M) — 124 passing (+16 Y.Assumptions, +9 Adaptive.Assumptions)
 - [ ] Step 2a — Differential harness (M)
 - [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
 - [ ] Step 3 — `Ylmish.Text` (M)
@@ -327,6 +327,8 @@ No code changes. Get the toolchain running per `AGENTS.md`, run `npm test`, reco
 
 *Check-in:* baseline test count; anything already broken on your machine; questions about the plan itself before work starts.
 
+*Decisions & lessons (executed 2026-07-04):* baseline 99 passing, 0 skipped, nothing broken. (PR #123 "establish test baseline" merged with an empty diff, so the count is recorded here instead.)
+
 ### Step 1 — Pin the assumptions (Yjs **and** Adaptive)
 
 Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs` (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 at minimum), and re-pin the Adaptify delta characterization (A1/L1: rebuild-regime positional rewrites; positional rebinding of nested adaptive objects; `HashMap` keyed reconcile) in `Adaptive.Assumptions.fs`. The reference branch has working versions of both files to adapt.
@@ -334,6 +336,14 @@ Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs`
 *Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs or Adaptify upgrade that changes semantics fails loudly.
 
 *Check-in:* test count; a one-line map from each assumption id (U*/A1) to its test name; any assumption that did **not** reproduce (that's a stop-the-line finding — it invalidates part of the design).
+
+*Decisions & lessons (executed 2026-07-04):*
+
+- Every assumption reproduced exactly as tabled — no stop-the-line findings. Assumption → test map (all in `Y.Assumptions.fs` under the same-named `testList`): U1 root map identity, U2a nested first-create race, U2b root-level create race, U3 shared nested Y.Text, U3b plain-string map value, U4 LWW tiebreak, U5b re-parenting an integrated type, U6 transaction origins, U7 observeDeep coverage, U8 concurrent array inserts, U9 delete vs edit-inside, U10 typed primitives in Y.Map, U11 replace vs concurrent edit, U13 concurrent structural move, U14 transaction batching, U15 unknown keys. A1/L1 in `Adaptive.Assumptions.fs`: three IndexList structural-op tests (minimal deltas), rebuild + reorder positional-rewrite tests, positional nested rebinding, and three HashMap keyed-reconcile tests (O(delta) ops; identity follows the key). Ported beyond the plan's minimum: U1, U3b, U7, U8, U10 (cheap, and each backs a design claim). Not ported: U5 (subsumed by U5b), U12 (subsumed by U2a).
+- The HashMap keyed-reconcile characterization needed a model with a `HashMap` field; added `MapModel` to the test common's `Example.fs` (Adaptify generates a keyed `ChangeableModelMap` for it, confirming the L1 contrast by construction).
+- Interpretation: U7's path-tracked events (`["list", 0]`) are pinned as *coverage* (event counts through one deep observer), not paths — the Fable.Yjs `YEvent` binding doesn't expose `path`. The binding gap is real and Step 6 (decode direction) will need `path` bound; noting rather than fixing here since Step 1 adds no production code.
+- Fable interop gotcha: an F# `int[]` compiles to a JS `Int32Array`, which Yjs rejects with "Unexpected content type" — U10 pins plain (boxed) arrays. Worth remembering for the codec's list encoding.
+- U5b makes Yjs log an internal `TypeError` to the console mid-suite; expected noise, documented in the test.
 
 ### Step 2a — Differential harness
 

--- a/tests/Ylmish.Tests/Adaptive.Assumptions.fs
+++ b/tests/Ylmish.Tests/Adaptive.Assumptions.fs
@@ -32,8 +32,7 @@ open Fable.Mocha
 open Expecto
 #endif
 
-type private DeltaCount = { Sets : int; Removes : int } with
-    member c.Total = c.Sets + c.Removes
+type private DeltaCount = { Sets : int; Removes : int }
 
 let private countOps (ops : ('k * ElementOperation<'v>) list) : DeltaCount =
     let sets = ops |> List.filter (fun (_, op) -> match op with Set _ -> true | _ -> false) |> List.length
@@ -127,9 +126,8 @@ let tests = testList "Adaptive.Assumptions" [
             // off item i survive a rebuild? No — position i's adaptive object is
             // reused for whatever lands there.
             let mkC (items : string list) : Model =
-                { PropA = ""; PropB = None
-                  PropC = items |> List.map (fun p -> { Prop0 = p }) |> IndexList.ofList
-                  PropD = IndexList.empty; PropE = { Prop0 = "" }; PropF = None }
+                { mk IndexList.empty with
+                    PropC = items |> List.map (fun p -> { Prop0 = p }) |> IndexList.ofList }
             let am = AdaptiveModel.Create (mkC [ "a"; "b" ])
             let at0Before = am.PropC |> AList.force |> IndexList.toList |> List.item 0
             // Prepend "x" by REBUILDING the list (fresh Indices) — the idiomatic update.
@@ -161,6 +159,19 @@ let tests = testList "Adaptive.Assumptions" [
             let c = measureItems before after
             Expect.equal c { Sets = 0; Removes = 1 }
                 "only the removed key produces an op"
+        }
+
+        test "wholesale rebuild editing one key's VALUE: 0 outer ops — absorbed in place" {
+            // The most load-bearing keyed behaviour: an in-place edit of an
+            // existing key does not surface on the outer amap at all — the
+            // nested AdaptiveSubmodel is updated in place (proven by reference
+            // in the identity test below). A regression that re-created the
+            // submodel on value-edit would surface here as a Set.
+            let before = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b" } ]
+            let after = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b2" } ]
+            let c = measureItems before after
+            Expect.equal c { Sets = 0; Removes = 0 }
+                "editing an existing key's value emits no outer map ops — the delta is absorbed by the nested adaptive object"
         }
 
         test "rebuilt HashMap keeps each key's adaptive object — identity follows the KEY" {

--- a/tests/Ylmish.Tests/Adaptive.Assumptions.fs
+++ b/tests/Ylmish.Tests/Adaptive.Assumptions.fs
@@ -1,0 +1,185 @@
+module Ylmish.Adaptive.Assumptions
+
+// Plan 0002, Step 1 — re-pin the Adaptify delta characterization (A1/L1).
+//
+// Characterization tests: no Ylmish production code is under test. Adapted
+// from the reference branch's Adaptive.Spike.fs (its 0006 Step 1), whose
+// findings plan 0002 imports as lesson L1:
+//
+//   Adaptify list deltas are POSITIONAL, not keyed. The idiomatic rebuild
+//   `{ m with Items = recompute () }` yields O(n) positional value-rewrites,
+//   and ChangeableModelList rebinds nested adaptive objects by position — a
+//   nested collaborative type hung off item i would be hijacked by whatever
+//   lands at position i.
+//
+// That is why `Encode.list` is restricted to value sequences by its type, and
+// why entities with identity go in `Encode.map` over HashMap — whose Adaptify
+// reconcile (ChangeableModelMap) is KEYED by construction, which the second
+// half of this file pins.
+//
+// What the generated code does (Example.g.fs): an IndexList field becomes a
+// clist and `Update` assigns the whole new IndexList; the delta is whatever
+// `ChangeableIndexList.Value <- new` computes by comparing Index keys. A
+// HashMap field becomes a ChangeableModelMap keyed by the map key.
+
+open FSharp.Data.Adaptive
+
+open Example
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+type private DeltaCount = { Sets : int; Removes : int } with
+    member c.Total = c.Sets + c.Removes
+
+let private countOps (ops : ('k * ElementOperation<'v>) list) : DeltaCount =
+    let sets = ops |> List.filter (fun (_, op) -> match op with Set _ -> true | _ -> false) |> List.length
+    let removes = ops |> List.filter (fun (_, op) -> match op with Remove -> true | _ -> false) |> List.length
+    { Sets = sets; Removes = removes }
+
+// -----------------------------------------------------------------------------
+// IndexList (positional): drive an AdaptiveModel from one whole model to the
+// next and count the IndexListDelta operations emitted on PropD.
+// -----------------------------------------------------------------------------
+
+let private mk (propD : IndexList<string>) : Model =
+    { PropA = ""; PropB = None; PropC = IndexList.empty
+      PropD = propD; PropE = { Prop0 = "" }; PropF = None }
+
+/// Count the delta PropD emits when the model goes from `before` to `after`.
+let private measurePropD (before : IndexList<string>) (after : IndexList<string>) : DeltaCount =
+    let am = AdaptiveModel.Create (mk before)
+    let reader = am.PropD.GetReader ()
+    // Prime: the first GetChanges reports the whole initial content; discard it
+    // so we measure only the incremental delta caused by the reassignment.
+    reader.GetChanges AdaptiveToken.Top |> ignore
+    transact (fun () -> am.Update (mk after))
+    reader.GetChanges AdaptiveToken.Top |> IndexListDelta.toList |> List.map (fun (i, op) -> box i, op) |> countOps
+
+// -----------------------------------------------------------------------------
+// HashMap (keyed): same measurement over MapModel.ItemsByKey.
+// -----------------------------------------------------------------------------
+
+let private measureItems (before : HashMap<string, Submodel>) (after : HashMap<string, Submodel>) : DeltaCount =
+    let am = AdaptiveMapModel.Create { ItemsByKey = before }
+    let reader = am.ItemsByKey.GetReader ()
+    reader.GetChanges AdaptiveToken.Top |> ignore
+    transact (fun () -> am.Update { ItemsByKey = after })
+    reader.GetChanges AdaptiveToken.Top |> HashMapDelta.toList |> List.map (fun (k, op) -> box k, op) |> countOps
+
+let private start = IndexList.ofList [ "a"; "b"; "c" ]
+
+let tests = testList "Adaptive.Assumptions" [
+
+    // ---- A1, identity-PRESERVING regime: structural ops on the previous
+    // IndexList keep Index identity, so each logical change is a minimal delta.
+
+    testList "A1 IndexList structural ops (identity-preserving)" [
+        test "append via .Add preserves Index: 1 Set" {
+            let c = measurePropD start (start.Add "d")
+            Expect.equal c { Sets = 1; Removes = 0 }
+                "appending one item touches exactly one Index — an O(1) delta"
+        }
+
+        test "prepend via .Prepend preserves Index: 1 Set" {
+            let c = measurePropD start (start.Prepend "x")
+            Expect.equal c { Sets = 1; Removes = 0 }
+                "prepend is also O(1): a/b/c keep their Indices, x gets a new one"
+        }
+
+        test "remove-middle via .RemoveAt preserves Index: 1 Remove" {
+            let c = measurePropD start (start.RemoveAt 1)
+            Expect.equal c { Sets = 0; Removes = 1 }
+                "removing one item is an O(1) delta — only the dropped Index is touched"
+        }
+    ]
+
+    // ---- A1, identity-DESTROYING regimes: rebuild-from-scratch and reorder
+    // degrade to positional value-rewrites. This is the L1 evidence for
+    // restricting Encode.list to value sequences.
+
+    testList "A1 IndexList rebuild (positional, identity-destroying)" [
+        test "rebuild via IndexList.ofList: positional rewrite, not minimal" {
+            // The idiomatic `{ model with Items = recompute () }`: the SAME
+            // logical prepend as the .Prepend case above — but fresh Indices.
+            let c = measurePropD start (IndexList.ofList [ "x"; "a"; "b"; "c" ])
+            // OBSERVED (pinned): 4 Sets, 0 Removes. computeDelta aligns the two
+            // lists POSITIONALLY, so a prepend reads as "position 0 changed a→x,
+            // position 1 b→a, position 2 c→b, position 3 added c". A logically
+            // O(1) prepend costs O(n) value-rewrites and loses item identity.
+            Expect.equal (c.Sets, c.Removes) (4, 0)
+                "rebuild-from-scratch defeats the diff: positional value-rewrite, not identity-stable"
+        }
+
+        test "reorder has no identity-preserving form: positional churn, never a move" {
+            let c = measurePropD start (IndexList.ofList [ "c"; "b"; "a" ])
+            // OBSERVED (pinned): reversing [a;b;c] is 2 Sets (positions 0 and 2
+            // swap values), 0 Removes — a positional value-rewrite, not a move.
+            Expect.equal (c.Sets, c.Removes) (2, 0)
+                "a reorder is positional value-churn — relevant to the structural-move limits (U13/L9)"
+        }
+
+        test "rebuilt list of submodels rebinds nested adaptive objects by POSITION, not identity" {
+            // The decisive nested-state result: would a collaborative type hung
+            // off item i survive a rebuild? No — position i's adaptive object is
+            // reused for whatever lands there.
+            let mkC (items : string list) : Model =
+                { PropA = ""; PropB = None
+                  PropC = items |> List.map (fun p -> { Prop0 = p }) |> IndexList.ofList
+                  PropD = IndexList.empty; PropE = { Prop0 = "" }; PropF = None }
+            let am = AdaptiveModel.Create (mkC [ "a"; "b" ])
+            let at0Before = am.PropC |> AList.force |> IndexList.toList |> List.item 0
+            // Prepend "x" by REBUILDING the list (fresh Indices) — the idiomatic update.
+            transact (fun () -> am.Update (mkC [ "x"; "a"; "b" ]))
+            let at0After = am.PropC |> AList.force |> IndexList.toList |> List.item 0
+            Expect.isTrue (System.Object.ReferenceEquals (at0Before, at0After))
+                "position 0's adaptive object is REUSED — nested state is rebound to the new positional occupant"
+            Expect.equal (at0After.Prop0 |> AVal.force) "x"
+                "the object that was item 'a' now holds 'x' — item a's nested state was hijacked"
+        }
+    ]
+
+    // ---- The contrast that makes Encode.map the identity primitive: a HashMap
+    // field reconciles BY KEY (ChangeableModelMap), so wholesale rebuilds emit
+    // O(delta) ops and nested adaptive objects stay with their key.
+
+    testList "A1 HashMap keyed reconcile (identity-preserving by construction)" [
+        test "wholesale rebuild adding one key: 1 Set — keyed, O(delta)" {
+            let before = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b" } ]
+            let after = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b" }; "x", { Prop0 = "x" } ]
+            let c = measureItems before after
+            Expect.equal c { Sets = 1; Removes = 0 }
+                "unchanged keys emit nothing; only the added key produces an op"
+        }
+
+        test "wholesale rebuild removing one key: 1 Remove" {
+            let before = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b" } ]
+            let after = HashMap.ofList [ "a", { Prop0 = "a" } ]
+            let c = measureItems before after
+            Expect.equal c { Sets = 0; Removes = 1 }
+                "only the removed key produces an op"
+        }
+
+        test "rebuilt HashMap keeps each key's adaptive object — identity follows the KEY" {
+            let am = AdaptiveMapModel.Create {
+                ItemsByKey = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b" } ]
+            }
+            let aBefore = am.ItemsByKey |> AMap.force |> HashMap.find "a"
+            // Rebuild wholesale, adding "x" and editing "b" — the same shape of
+            // update that hijacked nested state in the IndexList case.
+            transact (fun () -> am.Update {
+                ItemsByKey = HashMap.ofList [ "a", { Prop0 = "a" }; "b", { Prop0 = "b2" }; "x", { Prop0 = "x" } ]
+            })
+            let aAfter = am.ItemsByKey |> AMap.force |> HashMap.find "a"
+            Expect.isTrue (System.Object.ReferenceEquals (aBefore, aAfter))
+                "key 'a' keeps its adaptive object across a wholesale rebuild"
+            Expect.equal (aAfter.Prop0 |> AVal.force) "a"
+                "and it still holds item a's value — no positional hijack"
+            Expect.equal (am.ItemsByKey |> AMap.force |> HashMap.find "b" |> fun m -> m.Prop0 |> AVal.force) "b2"
+                "the edited key's object was updated in place"
+        }
+    ]
+]

--- a/tests/Ylmish.Tests/Y.Assumptions.fs
+++ b/tests/Ylmish.Tests/Y.Assumptions.fs
@@ -1,0 +1,428 @@
+module Ylmish.Y.Assumptions
+
+// Plan 0002, Step 1 — pin the Yjs semantics the redesign depends on.
+//
+// These are characterization tests: no Ylmish production code is under test.
+// Each test ports one runnable experiment from doc/plans/0002-assumptions/
+// (experiments.mjs / experiments2.mjs) and pins the observed behaviour, so a
+// Yjs upgrade that changes semantics fails CI loudly. Test names carry the
+// assumption ids (U1..U15) from the plan's "Validated assumptions" table;
+// each comment states the design consequence that rests on the result.
+
+open Yjs
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+// Unambiguous aliases — `Y` is overloaded across the Yjs module, the Yjs class,
+// and Ylmish.Y, so spell the raw Yjs types out for annotations and casts.
+type private Doc = Yjs.Utils.Doc.Doc
+type private YText = Yjs.Types.YText.YText
+type private YMap<'a> = Yjs.Types.YMap.YMap<'a>
+type private YArray<'a> = Yjs.Types.YArray.YArray<'a>
+
+/// Push all of `src`'s state into `dst` (one direction of a network round-trip).
+let private sync (src : Doc) (dst : Doc) =
+    Y.applyUpdate (dst, Y.encodeStateAsUpdate src)
+
+/// Full exchange, both directions.
+let private exchange (a : Doc) (b : Doc) =
+    sync a b
+    sync b a
+
+/// A doc with a deterministic clientID (Yjs breaks LWW ties by clientID, U4).
+let private docWithClient (id : float) : Doc =
+    let d = Y.Doc.Create ()
+    d.clientID <- id
+    d
+
+let private root (d : Doc) : YMap<obj> = d.getMap ()
+
+let tests = testList "Y.Assumptions" [
+
+    // U1 — argless doc.getMap() returns the root map named "", same instance
+    // every call. Consequence: root binding is stable; consumers need not name
+    // a root map.
+    testList "U1 root map identity" [
+        test "getMap() is idempotent and equals getMap(\"\")" {
+            let doc = Y.Doc.Create ()
+            let m1 : YMap<obj> = doc.getMap ()
+            let m2 : YMap<obj> = doc.getMap ()
+            let m3 : YMap<obj> = doc.getMap ""
+            Expect.isTrue (System.Object.ReferenceEquals (m1, m2))
+                "argless getMap must return the same instance on repeated calls"
+            Expect.isTrue (System.Object.ReferenceEquals (m1, m3))
+                "argless getMap must be the root map named the empty string"
+        }
+    ]
+
+    // U2a — the nested first-create race. Two clients each create a fresh
+    // nested type under the same map key, then sync: one client's ENTIRE
+    // subtree wins; the other's data is silently discarded. Consequence: never
+    // create containers eagerly at init; the residual race is the documented
+    // app-design limitation (offline-creatable entities need unique keys).
+    testList "U2a nested first-create race" [
+        test "concurrent fresh nested arrays under one key: one subtree wins wholesale" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let a1 : YArray<string> = Y.Array.Create ()
+            a1.push [| "from-d1" |]
+            (root d1).set ("todos", box a1) |> ignore
+            let a2 : YArray<string> = Y.Array.Create ()
+            a2.push [| "from-d2" |]
+            (root d2).set ("todos", box a2) |> ignore
+
+            exchange d1 d2
+
+            let read (d : Doc) =
+                ((root d).get "todos" |> Option.get :?> YArray<string>).toArray () |> List.ofSeq
+            let r1 = read d1
+            let r2 = read d2
+            Expect.equal r1 r2 "docs converge (CRDT guarantees agreement)..."
+            Expect.equal r1.Length 1
+                "...but only one subtree survives — the loser's items are LOST"
+            Expect.isTrue (r1 = [ "from-d1" ] || r1 = [ "from-d2" ])
+                "the survivor is exactly one peer's array"
+        }
+    ]
+
+    // U2b — the same race with ROOT-level types merges by name: both sides'
+    // items survive. Consequence: root types are safe to get-or-create.
+    testList "U2b root-level create race" [
+        test "concurrent root arrays with the same name merge, both items survive" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            (d1.getArray "todos" : YArray<string>).push [| "from-d1" |]
+            (d2.getArray "todos" : YArray<string>).push [| "from-d2" |]
+
+            exchange d1 d2
+
+            let read (d : Doc) = (d.getArray "todos" : YArray<string>).toArray () |> List.ofSeq
+            Expect.equal (read d1) (read d2) "docs converge"
+            Expect.equal (read d1 |> List.sort) [ "from-d1"; "from-d2" ]
+                "root types with the same name merge by name — no wholesale loss"
+        }
+    ]
+
+    // U3 — concurrent edits to ONE shared nested Y.Text interleave and
+    // converge. This is the whole point of the redesign: text must bind to an
+    // existing instance, created once.
+    testList "U3 shared nested Y.Text" [
+        test "concurrent edits interleave and converge" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let t = Y.Text.Create "hello"
+            (root d1).set ("body", box t) |> ignore
+            exchange d1 d2 // both now share the same text
+
+            let text (d : Doc) = (root d).get "body" |> Option.get :?> YText
+            (text d1).insert (5, " world")
+            (text d2).insert (0, "oh, ")
+            exchange d1 d2
+
+            let s1 = (text d1).toString ()
+            let s2 = (text d2).toString ()
+            Expect.equal s1 s2 "shared nested Y.Text converges"
+            Expect.equal s1 "oh, hello world"
+                "both peers' insertions survive and interleave (observed: 'oh, hello world')"
+        }
+    ]
+
+    // U3b — a string field stored as a plain map value resolves concurrent
+    // sets by LWW: issue #83's failure mode. Consequence: plain values are
+    // honest LWW registers; the codec must let consumers choose text vs
+    // register per field.
+    testList "U3b plain-string map value" [
+        test "concurrent set clobbers — LWW register, not a merge" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            (root d1).set ("body", box "hello") |> ignore
+            exchange d1 d2
+
+            (root d1).set ("body", box "hello world") |> ignore
+            (root d2).set ("body", box "oh, hello") |> ignore
+            exchange d1 d2
+
+            let v (d : Doc) = (root d).get "body" |> Option.get |> unbox<string>
+            Expect.equal (v d1) (v d2) "docs converge"
+            Expect.isTrue (v d1 = "hello world" || v d1 = "oh, hello")
+                "exactly one write survives — the other is clobbered"
+            Expect.equal (v d1) "oh, hello"
+                "the winner is the higher clientID's write (see U4), not a merge"
+        }
+    ]
+
+    // U4 — what decides the LWW winner: deterministic and order-independent,
+    // higher clientID wins among concurrent sets. NOT wall-clock. Consequence:
+    // document honestly — "last writer" is an arbitrary-but-convergent tiebreak.
+    testList "U4 LWW tiebreak" [
+        test "higher clientID wins, independent of sync order" {
+            for (c1, c2) in [ 1.0, 2.0; 2.0, 1.0; 100.0, 5.0 ] do
+                let d1 = docWithClient c1
+                let d2 = docWithClient c2
+                (root d1).set ("k", box $"v-from-{c1}") |> ignore
+                (root d2).set ("k", box $"v-from-{c2}") |> ignore
+                exchange d1 d2
+                let expected = $"v-from-{max c1 c2}"
+                let v (d : Doc) = (root d).get "k" |> Option.get |> unbox<string>
+                Expect.equal (v d1) expected $"clientIDs ({c1}, {c2}): d1 must hold the higher client's write"
+                Expect.equal (v d2) expected $"clientIDs ({c1}, {c2}): d2 must agree"
+        }
+    ]
+
+    // U5b — re-setting an already-integrated Y type under another key does NOT
+    // throw at the call site; the doc corrupts and a later sync to a peer
+    // throws. Consequence: the public API must make re-parenting impossible by
+    // construction — you cannot guard it with try/catch at the write site.
+    // (Yjs also logs an internal TypeError to the console here; that noise is
+    // expected and harmless.)
+    testList "U5b re-parenting an integrated type" [
+        test "no throw at the call site, but the doc becomes unsyncable" {
+            let d1 = Y.Doc.Create ()
+            let t = Y.Text.Create "x"
+            (root d1).set ("a", box t) |> ignore
+
+            let mutable setThrew = false
+            try (root d1).set ("b", box t) |> ignore
+            with _ -> setThrew <- true
+            Expect.isFalse setThrew
+                "the corrupting re-set does NOT throw at the call site — no local guard is possible"
+
+            let d2 = Y.Doc.Create ()
+            let mutable syncThrew = false
+            try sync d1 d2
+            with _ -> syncThrew <- true
+            Expect.isTrue syncThrew
+                "a later applyUpdate on a peer throws — the corruption surfaces far from its cause"
+        }
+    ]
+
+    // U6 — transaction origins propagate to observers: doc.transact's origin
+    // and applyUpdate's origin both reach observers, with a `local` flag.
+    // Consequence: echo suppression via a per-binding origin token replaces
+    // boolean reentrancy flags.
+    testList "U6 transaction origins" [
+        test "transact origin, default origin and applyUpdate origin all reach observers" {
+            let d1 = Y.Doc.Create ()
+            let seen = ResizeArray<string * bool> ()
+            (root d1).observe (fun _e tr ->
+                let origin = tr.origin |> Option.map string |> Option.defaultValue "null"
+                seen.Add (origin, tr.local))
+
+            d1.transact ((fun _ -> (root d1).set ("k", box 1) |> ignore), box "my-origin")
+            (root d1).set ("k", box 2) |> ignore
+            let d2 = Y.Doc.Create ()
+            (root d2).set ("k", box 3) |> ignore
+            Y.applyUpdate (d1, Y.encodeStateAsUpdate d2, box "remote-origin")
+
+            Expect.equal (List.ofSeq seen)
+                [ "my-origin", true; "null", true; "remote-origin", false ]
+                "origins propagate verbatim, applyUpdate carries its own origin, and `local` distinguishes remote applies"
+        }
+    ]
+
+    // U7 — observeDeep on the root sees nested edits (typed events reaching
+    // the root from arbitrarily deep). Consequence: ONE observer covers the
+    // whole bound tree, including custom elements (L4, L6).
+    testList "U7 observeDeep coverage" [
+        test "one deep observer on the root sees nested text, array and map edits" {
+            let d1 = Y.Doc.Create ()
+            let t = Y.Text.Create ""
+            (root d1).set ("body", box t) |> ignore
+            let mutable events = 0
+            (root d1).observeDeep (fun evts _tr -> events <- events + evts.Count)
+
+            t.insert (0, "hi")                               // nested text edit
+            let arr : YArray<obj> = Y.Array.Create ()
+            (root d1).set ("list", box arr) |> ignore        // root map edit
+            let inner : YMap<obj> = Y.Map.Create ()
+            arr.push [| box inner |]                         // nested array edit
+            inner.set ("inner", box "v") |> ignore           // doubly-nested map edit
+
+            Expect.equal events 4
+                "every edit — root-level and nested — surfaces through the single deep observer"
+        }
+    ]
+
+    // U8 — concurrent Y.Array inserts at the same position: both survive, in a
+    // deterministic order. Consequence: lists merge; safe default for value
+    // sequences.
+    testList "U8 concurrent array inserts" [
+        test "both inserts at position 0 survive with deterministic order" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let arr : YArray<string> = Y.Array.Create ()
+            arr.push [| "base" |]
+            (root d1).set ("xs", box arr) |> ignore
+            exchange d1 d2
+
+            let xs (d : Doc) = (root d).get "xs" |> Option.get :?> YArray<string>
+            (xs d1).insert (0, [| "from-d1" |])
+            (xs d2).insert (0, [| "from-d2" |])
+            exchange d1 d2
+
+            let r1 = (xs d1).toArray () |> List.ofSeq
+            let r2 = (xs d2).toArray () |> List.ofSeq
+            Expect.equal r1 r2 "docs converge"
+            Expect.equal (List.sort r1) [ "base"; "from-d1"; "from-d2" ]
+                "both concurrent inserts survive alongside the base item"
+        }
+    ]
+
+    // U9 — deleting an item vs a concurrent edit inside it: delete wins, the
+    // edit is lost. Documented limit.
+    testList "U9 delete vs edit-inside" [
+        test "concurrent delete of a container beats an edit inside it" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let item : YMap<obj> = Y.Map.Create ()
+            item.set ("title", box "a") |> ignore
+            let arr : YArray<obj> = Y.Array.Create ()
+            arr.push [| box item |]
+            (root d1).set ("xs", box arr) |> ignore
+            exchange d1 d2
+
+            let xs (d : Doc) = (root d).get "xs" |> Option.get :?> YArray<obj>
+            (xs d1).delete (0, 1)                                        // d1 deletes the item
+            ((xs d2).get 0 :?> YMap<obj>).set ("title", box "b") |> ignore // d2 edits inside it
+            exchange d1 d2
+
+            Expect.equal ((xs d1).toArray().Count) 0 "delete wins on d1"
+            Expect.equal ((xs d2).toArray().Count) 0 "delete wins on d2 — the concurrent edit is lost"
+        }
+    ]
+
+    // U10 — Y.Map holds any JSON value, not just strings. Consequence: the v1
+    // codec's Element<string> restriction is unnecessary; v2 elements carry
+    // typed primitives. (The .mjs run also pins null, plain objects and
+    // undefined; here we pin the payloads the v2 Value sub-language needs.)
+    testList "U10 typed primitives in Y.Map" [
+        test "numbers, floats, bools, strings and arrays round-trip" {
+            let d = Y.Doc.Create ()
+            let m = root d
+            m.set ("num", box 42) |> ignore
+            m.set ("float", box 1.5) |> ignore
+            m.set ("bool", box true) |> ignore
+            m.set ("str", box "s") |> ignore
+            // NB: an F# int[] compiles to a JS Int32Array under Fable, which Yjs
+            // rejects ("Unexpected content type") — a plain JS array is required.
+            m.set ("arr", box [| box 1; box 2 |]) |> ignore
+
+            Expect.equal (m.get "num" |> Option.get |> unbox<int>) 42 "int survives"
+            Expect.equal (m.get "float" |> Option.get |> unbox<float>) 1.5 "float survives"
+            Expect.equal (m.get "bool" |> Option.get |> unbox<bool>) true "bool survives"
+            Expect.equal (m.get "str" |> Option.get |> unbox<string>) "s" "string survives"
+            Expect.equal (m.get "arr" |> Option.get |> unbox<obj[]> |> Array.map unbox<int> |> List.ofArray) [ 1; 2 ]
+                "plain arrays survive"
+        }
+    ]
+
+    // U11 — replacing a nested Y.Text with a fresh instance while a peer edits
+    // the old one: the replacement wins and the peer's edits are lost. This is
+    // precisely why materialize-per-update can never merge. Bind, never replace.
+    testList "U11 replace vs concurrent edit" [
+        test "replacing a nested Y.Text discards the peer's concurrent edits" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let t1 = Y.Text.Create "v1"
+            (root d1).set ("body", box t1) |> ignore
+            exchange d1 d2
+
+            let oldRef = (root d2).get "body" |> Option.get :?> YText
+            // d1 replaces the Y.Text wholesale (exactly what materialize does today)
+            (root d1).set ("body", box (Y.Text.Create "v2")) |> ignore
+            // d2 concurrently edits the OLD text
+            oldRef.insert (2, "!")
+            exchange d1 d2
+
+            let read (d : Doc) = ((root d).get "body" |> Option.get :?> YText).toString ()
+            Expect.equal (read d1) "v2" "the replacement wins on d1"
+            Expect.equal (read d2) "v2" "the replacement wins on d2 — the '!' edit is lost"
+        }
+    ]
+
+    // U13 — a concurrent "move" (delete+insert) of the same list item
+    // duplicates it. Known Yjs v13 limit; the keyed-map + order-field pattern
+    // avoids structural moves entirely (L9).
+    testList "U13 concurrent structural move" [
+        test "both peers move the same item: it is duplicated" {
+            let d1 = docWithClient 1.0
+            let d2 = docWithClient 2.0
+            let arr : YArray<string> = Y.Array.Create ()
+            arr.push [| "a"; "b"; "c" |]
+            (root d1).set ("xs", box arr) |> ignore
+            exchange d1 d2
+
+            let move (d : Doc) =
+                let xs = (root d).get "xs" |> Option.get :?> YArray<string>
+                d.transact (fun _ ->
+                    let v = xs.get 0
+                    xs.delete (0, 1)
+                    xs.push [| v |])
+            move d1
+            move d2
+            exchange d1 d2
+
+            let read (d : Doc) =
+                ((root d).get "xs" |> Option.get :?> YArray<string>).toArray () |> List.ofSeq
+            Expect.equal (read d1) (read d2) "docs converge"
+            Expect.equal (read d1) [ "b"; "c"; "a"; "a" ]
+                "the moved item is DUPLICATED — delete+insert is not a move"
+        }
+    ]
+
+    // U14 — one doc.transact spanning many nested types yields ONE observeDeep
+    // batch containing all events. Consequence: remote changes apply as a
+    // single Elmish Set per transaction — atomic model updates.
+    testList "U14 transaction batching" [
+        test "one transact over text + array + map = one deep-observer batch of 3 events" {
+            let d = Y.Doc.Create ()
+            let t = Y.Text.Create ""
+            let a : YArray<obj> = Y.Array.Create ()
+            (root d).set ("t", box t) |> ignore
+            (root d).set ("a", box a) |> ignore
+
+            let mutable batches = 0
+            let mutable events = 0
+            (root d).observeDeep (fun evts _tr ->
+                batches <- batches + 1
+                events <- events + evts.Count)
+
+            d.transact (fun _ ->
+                t.insert (0, "hi")
+                a.push [| box 1 |]
+                (root d).set ("k", box "v") |> ignore)
+
+            Expect.equal batches 1 "all changes inside one transact arrive as ONE batch"
+            Expect.equal events 3 "the batch carries one event per changed type"
+        }
+    ]
+
+    // U15 — updates containing keys a client doesn't understand apply cleanly;
+    // unknown keys are preserved and readable. Consequence: forward
+    // compatibility is free if the runtime stops deleting unknown keys —
+    // the foundation for the dual-key migration recipe.
+    testList "U15 unknown keys" [
+        test "a client applies and preserves keys it does not understand" {
+            let oldClient = Y.Doc.Create ()
+            let newClient = Y.Doc.Create ()
+            (root oldClient).set ("v1", box "old-data") |> ignore
+            exchange oldClient newClient
+
+            let t = Y.Text.Create "new-data"
+            (root newClient).set ("v2", box t) |> ignore
+            let mutable err = false
+            try exchange oldClient newClient
+            with _ -> err <- true
+
+            Expect.isFalse err "syncing a doc with unknown keys must not throw"
+            Expect.isTrue ((root oldClient).has "v2")
+                "the unknown key is preserved on the old client"
+            Expect.equal ((root oldClient).get "v1" |> Option.get |> unbox<string>) "old-data"
+                "the old client's own data is untouched"
+        }
+    ]
+]

--- a/tests/Ylmish.Tests/Y.Assumptions.fs
+++ b/tests/Ylmish.Tests/Y.Assumptions.fs
@@ -82,10 +82,9 @@ let tests = testList "Y.Assumptions" [
             let r1 = read d1
             let r2 = read d2
             Expect.equal r1 r2 "docs converge (CRDT guarantees agreement)..."
-            Expect.equal r1.Length 1
-                "...but only one subtree survives — the loser's items are LOST"
-            Expect.isTrue (r1 = [ "from-d1" ] || r1 = [ "from-d2" ])
-                "the survivor is exactly one peer's array"
+            Expect.equal r1 [ "from-d2" ]
+                "...but only ONE subtree survives — the higher clientID's (the same \
+                 tiebreak as U4) — and the loser's items are LOST"
         }
     ]
 
@@ -148,10 +147,8 @@ let tests = testList "Y.Assumptions" [
 
             let v (d : Doc) = (root d).get "body" |> Option.get |> unbox<string>
             Expect.equal (v d1) (v d2) "docs converge"
-            Expect.isTrue (v d1 = "hello world" || v d1 = "oh, hello")
-                "exactly one write survives — the other is clobbered"
             Expect.equal (v d1) "oh, hello"
-                "the winner is the higher clientID's write (see U4), not a merge"
+                "exactly one write survives — the higher clientID's (see U4) — the other is clobbered, not merged"
         }
     ]
 
@@ -233,7 +230,11 @@ let tests = testList "Y.Assumptions" [
             let t = Y.Text.Create ""
             (root d1).set ("body", box t) |> ignore
             let mutable events = 0
-            (root d1).observeDeep (fun evts _tr -> events <- events + evts.Count)
+            let mutable textTargeted = false
+            (root d1).observeDeep (fun evts _tr ->
+                events <- events + evts.Count
+                for e in evts do
+                    if System.Object.ReferenceEquals (box e.target, box t) then textTargeted <- true)
 
             t.insert (0, "hi")                               // nested text edit
             let arr : YArray<obj> = Y.Array.Create ()
@@ -244,6 +245,11 @@ let tests = testList "Y.Assumptions" [
 
             Expect.equal events 4
                 "every edit — root-level and nested — surfaces through the single deep observer"
+            // The Fable binding doesn't expose YEvent.path, so pin routing via the
+            // event's TARGET instead: the nested text's event carries the Y.Text
+            // instance itself. (Step 6's decode direction will want `path` bound.)
+            Expect.isTrue textTargeted
+                "the nested text edit's deep event targets the Y.Text instance — the root observer can route without paths"
         }
     ]
 
@@ -267,8 +273,10 @@ let tests = testList "Y.Assumptions" [
             let r1 = (xs d1).toArray () |> List.ofSeq
             let r2 = (xs d2).toArray () |> List.ofSeq
             Expect.equal r1 r2 "docs converge"
-            Expect.equal (List.sort r1) [ "base"; "from-d1"; "from-d2" ]
-                "both concurrent inserts survive alongside the base item"
+            Expect.equal r1 [ "from-d1"; "from-d2"; "base" ]
+                "both concurrent inserts survive, in the deterministic converged order \
+                 (observed: lower clientID's insert first) — the order IS the pin; \
+                 a flipped insert tiebreak must fail here"
         }
     ]
 
@@ -297,10 +305,10 @@ let tests = testList "Y.Assumptions" [
 
     // U10 — Y.Map holds any JSON value, not just strings. Consequence: the v1
     // codec's Element<string> restriction is unnecessary; v2 elements carry
-    // typed primitives. (The .mjs run also pins null, plain objects and
-    // undefined; here we pin the payloads the v2 Value sub-language needs.)
+    // typed primitives. (The .mjs run also pins plain objects and undefined;
+    // here we pin the payloads the v2 Value sub-language needs, plus null.)
     testList "U10 typed primitives in Y.Map" [
-        test "numbers, floats, bools, strings and arrays round-trip" {
+        test "numbers, floats, bools, strings, arrays and null are stored" {
             let d = Y.Doc.Create ()
             let m = root d
             m.set ("num", box 42) |> ignore
@@ -310,6 +318,7 @@ let tests = testList "Y.Assumptions" [
             // NB: an F# int[] compiles to a JS Int32Array under Fable, which Yjs
             // rejects ("Unexpected content type") — a plain JS array is required.
             m.set ("arr", box [| box 1; box 2 |]) |> ignore
+            m.set ("nul", null) |> ignore
 
             Expect.equal (m.get "num" |> Option.get |> unbox<int>) 42 "int survives"
             Expect.equal (m.get "float" |> Option.get |> unbox<float>) 1.5 "float survives"
@@ -317,6 +326,12 @@ let tests = testList "Y.Assumptions" [
             Expect.equal (m.get "str" |> Option.get |> unbox<string>) "s" "string survives"
             Expect.equal (m.get "arr" |> Option.get |> unbox<obj[]> |> Array.map unbox<int> |> List.ofArray) [ 1; 2 ]
                 "plain arrays survive"
+            // A stored JS null is a real Y.Map value, but the Fable binding
+            // collapses `get` to 'T option, so null reads back as None —
+            // indistinguishable from a missing key. Pin presence via `has`;
+            // the codec's option semantics must NOT rely on null through `get`.
+            Expect.isTrue (m.has "nul")
+                "null is stored as a real value (readable only via has under Fable)"
         }
     ]
 

--- a/tests/Ylmish.Tests/Ylmish.Tests.fs
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fs
@@ -4,6 +4,7 @@ open Ylmish
 
 let tests = [
    Adaptive.Codec.tests
+   Adaptive.Assumptions.tests
    Y.Delta.tests
    Y.Text.tests
    Y.Array.tests

--- a/tests/Ylmish.Tests/Ylmish.Tests.fs
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fs
@@ -10,6 +10,7 @@ let tests = [
    Y.Map.tests
    Y.Element.tests
    Y.Doc.tests
+   Y.Assumptions.tests
    Program.tests
    TodoCollaborative.tests
 ]

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="common\Example.g.fs" />
     <Compile Include="common\Elmish.fs" />
     <Compile Include="Adaptive.Codec.fs" />
+    <Compile Include="Adaptive.Assumptions.fs" />
     <Compile Include="Y.Delta.fs" />
     <Compile Include="Y.Text.fs" />
     <Compile Include="Y.Array.fs" />

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="Y.Map.fs" />
     <Compile Include="Y.Element.fs" />
     <Compile Include="Y.Doc.fs" />
+    <Compile Include="Y.Assumptions.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="TodoCollaborative.fs" />
     <Compile Include="Ylmish.Tests.fs" />

--- a/tests/Ylmish.Tests/common/Example.fs
+++ b/tests/Ylmish.Tests/common/Example.fs
@@ -23,6 +23,12 @@ and [<ModelType>] Model = {
 and [<ModelType>] Submodel = {
     Prop0 : string
 }
+/// A keyed collection, as plan 0002 prescribes for entities with identity
+/// (`Encode.map` over `HashMap<key, _>`). Used by Adaptive.Assumptions.fs to
+/// characterize Adaptify's keyed reconcile.
+and [<ModelType>] MapModel = {
+    ItemsByKey : HashMap<string, Submodel>
+}
 
 module Model =
     let update msg model =

--- a/tests/Ylmish.Tests/common/Example.g.fs
+++ b/tests/Ylmish.Tests/common/Example.g.fs
@@ -1,5 +1,5 @@
-//faeb7074-59b6-18d2-bb45-ac1b0ebca0de
-//f6dbec3f-031b-62ea-3685-40fa122835b6
+//3fca5087-7243-cba1-a08e-f34761d10038
+//3fb1ef17-1c48-6314-c9df-c84836673833
 #nowarn "49" // upper case patterns
 #nowarn "66" // upcast is unncecessary
 #nowarn "1337" // internal types
@@ -64,4 +64,22 @@ type AdaptiveSubmodel(value : Submodel) =
             _Prop0_.Value <- value.Prop0
     member __.Current = __adaptive
     member __.Prop0 = _Prop0_ :> FSharp.Data.Adaptive.aval<Microsoft.FSharp.Core.string>
+[<System.Diagnostics.CodeAnalysis.SuppressMessage("NameConventions", "*")>]
+type AdaptiveMapModel(value : MapModel) =
+    let _ItemsByKey_ =
+        let inline __arg2 (m : AdaptiveSubmodel) (v : Submodel) =
+            m.Update(v)
+            m
+        FSharp.Data.Traceable.ChangeableModelMap(value.ItemsByKey, (fun (v : Submodel) -> AdaptiveSubmodel(v)), __arg2, (fun (m : AdaptiveSubmodel) -> m))
+    let mutable __value = value
+    let __adaptive = FSharp.Data.Adaptive.AVal.custom((fun (token : FSharp.Data.Adaptive.AdaptiveToken) -> __value))
+    static member Create(value : MapModel) = AdaptiveMapModel(value)
+    static member Unpersist = Adaptify.Unpersist.create (fun (value : MapModel) -> AdaptiveMapModel(value)) (fun (adaptive : AdaptiveMapModel) (value : MapModel) -> adaptive.Update(value))
+    member __.Update(value : MapModel) =
+        if Microsoft.FSharp.Core.Operators.not((FSharp.Data.Adaptive.ShallowEqualityComparer<MapModel>.ShallowEquals(value, __value))) then
+            __value <- value
+            __adaptive.MarkOutdated()
+            _ItemsByKey_.Update(value.ItemsByKey)
+    member __.Current = __adaptive
+    member __.ItemsByKey = _ItemsByKey_ :> FSharp.Data.Adaptive.amap<Microsoft.FSharp.Core.string, AdaptiveSubmodel>
 


### PR DESCRIPTION
Port doc/plans/0002-assumptions/*.mjs to Y.Assumptions.fs: U1, U2a/U2b,
U3, U3b, U4, U5b, U6, U7, U8, U9, U10, U11, U13, U14, U15. Each test pins
the observed Yjs behaviour a design decision in plan 0002 rests on, so a
Yjs upgrade that changes semantics fails CI loudly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KcjnVqxtZA6v2J42xf436y