### PR TITLE
Plan 0002 Step 0: record baseline (99 passing)

### DIFF
--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -307,7 +307,7 @@ For the engineer executing this (competent F#, new to this codebase):
 
 ### Progress
 
-- [ ] Step 0 — Baseline (S)
+- [x] Step 0 — Baseline (S) — **99 passing, 0 pending, 0 failing**
 - [ ] Step 1 — Pin the assumptions (M)
 - [ ] Step 2a — Differential harness (M)
 - [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
@@ -326,6 +326,14 @@ For the engineer executing this (competent F#, new to this codebase):
 No code changes. Get the toolchain running per `AGENTS.md`, run `npm test`, record the passing/skipped counts in *Progress*, and skim `src/Ylmish/Y.fs`, `Adaptive.Codec.fs`, `Program.fs` plus this plan's *Validated assumptions* table.
 
 *Check-in:* baseline test count; anything already broken on your machine; questions about the plan itself before work starts.
+
+**Done (baseline established).**
+
+- **Test count:** `npm test` → **99 passing, 0 pending, 0 failing** (~0.85s). This is the baseline; every subsequent check-in reports against it.
+- **Toolchain:** the environment shipped without a .NET SDK, so `npm install` (which runs `dotnet restore && dotnet tool restore`) failed at first. Installed .NET SDK `10.0.300` per `global.json` (via `dotnet-install.sh` to `/root/.dotnet`); after that, restore and tests are green. Fable `5.1.0`, Adaptify `1.3.7`, Femto `0.12.0` restored as local tools. Node `v22.22.2`.
+- **Nothing broken.** One pre-existing benign restore warning: `NU1608` — `YoloDev.Expecto.TestSdk 0.13.3` wants `Expecto < 10` but `10.2.3` resolved. Tests pass regardless; left untouched (out of scope for this step).
+- **Files skimmed:** `Y.fs` (Delta/Text/Array/Map `attach*` plumbing with boolean `active` reentrancy guards — the substance Step 5 will re-home under `Ylmish.Internal` with origin tokens; `Doc.materialize`/`dematerialize` — the whole-tree path this plan replaces, and note `materialize` deletes unrecognised root keys, exactly the U15 anti-behaviour), `Adaptive.Codec.fs` (the v1 codec — `Element<'Value>` union `Value | AList | AMap`, `Encode`/`Decode`, `Decoder.ask` Reader already present), `Program.fs` (`withYlmish` running on materialize + a `observeDeep` handler gated by an `isWritingToYDoc` bool; ~330 lines of commented-out prior codec sketches below the live code — candidates for Step 7's deletion).
+- **No blocking questions.** The plan's Step 0 premise holds; proceeding to Step 1 is unblocked.
 
 ### Step 1 — Pin the assumptions (Yjs **and** Adaptive)
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -308,7 +308,7 @@ For the engineer executing this (competent F#, new to this codebase):
 ### Progress
 
 - [x] Step 0 — Baseline (S) — **99 passing, 0 pending, 0 failing**
-- [ ] Step 1 — Pin the assumptions (M)
+- [x] Step 1 — Pin the assumptions (M) — **121 passing (+22)**
 - [ ] Step 2a — Differential harness (M)
 - [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
 - [ ] Step 3 — `Ylmish.Text` (M)
@@ -342,6 +342,36 @@ Port `doc/plans/0002-assumptions/*.mjs` to `tests/Ylmish.Tests/Y.Assumptions.fs`
 *Acceptance:* suite green; every design-consequence claim in this plan is enforced by CI, so a Yjs or Adaptify upgrade that changes semantics fails loudly.
 
 *Check-in:* test count; a one-line map from each assumption id (U*/A1) to its test name; any assumption that did **not** reproduce (that's a stop-the-line finding — it invalidates part of the design).
+
+**Done.**
+
+- **Test count:** 99 → **121 passing** (+22), 0 pending, 0 failing. New files: `tests/Ylmish.Tests/Y.Assumptions.fs` (16 tests, U-ids) and `tests/Ylmish.Tests/Adaptive.Assumptions.fs` (6 tests, A1/L1). Both wired into `Ylmish.Tests.fsproj` and the aggregate list. Ground truth captured by running `doc/plans/0002-assumptions/*.mjs` against the pinned yjs (13.6.x) first, then asserted.
+- **Every assumption reproduced.** No stop-the-line findings. The two Adaptify op-count pins landed exactly on the reference-branch values in this environment (FSharp.Data.Adaptive 1.2.26 under Fable, Adaptify 1.3.7): rebuild-prepend = 4 Sets/0 Removes, reverse = 2 Sets/0 Removes.
+- **Assumption → test name (Yjs, `Y.Assumptions`):**
+  - U1 → "getMap() returns the same instance on repeated calls"
+  - U2a → "each peer creates its own Y.Array under the same key — one side is lost"
+  - U2b → "two peers naming the same root array — both items survive"
+  - U3 → "concurrent inserts on a shared Y.Text both survive"
+  - U3b → "two peers set the same key to different strings — one is lost"
+  - U4 → "winner is order-independent and picks the higher clientID"
+  - U5b → "re-setting an integrated Y.Text under another key breaks a later sync"
+  - U6 → "explicit origin and remote-apply origin reach observers with local flags"
+  - U7 → "a nested Y.Text edit fires the root's observeDeep, targeting the text"
+  - U8 → "two peers insert at the same position — both items survive"
+  - U9 → "one peer deletes an item while the other edits inside it — delete wins"
+  - U10 → "number, bool, null and string round-trip through a Y.Map value"
+  - U11 → "replacement wins; a concurrent edit of the old text is lost"
+  - U13 → "both peers move the same item to the end — it appears twice"
+  - U14 → "a transact touching text, array and a map key fires one deep batch"
+  - U15 → "an old client applies an update adding an unknown key without loss"
+- **Assumption → test name (Adaptive, `Adaptive.Assumptions (A1 / L1)`):** A1 is pinned by six tests — the three identity-preserving cases (append/prepend/remove = minimal delta), the two identity-destroying cases (rebuild = positional 4-op rewrite; reorder = 2-op churn), and the nested-state hazard ("rebuilt list of submodels rebinds inner adaptive objects BY POSITION, not by id"), which is the exact corruption L1's `Encode.list`-values-only rule prevents.
+
+**Decisions & lessons (Step 1):**
+
+- **Kept the plan's U-numbering, not the reference branch's A1–A6 scheme.** The reference `Y.Assumptions.fs` covered a different (smaller) subset under its own ids and encoded the *flattening* design's needs; I re-derived the required set (U2a/U2b, U3, U4, U5b, U6, U9, U11, U13, U14, U15 + the cheap U1/U3b/U7/U8/U10) straight from the plan's table and the `.mjs` scripts so each test maps 1:1 to a plan row.
+- **U5b is asserted as an invariant, not an exact failure mode.** In yjs 13.6.x, re-parenting an integrated type *does not throw at the call site* — it corrupts, and a later `applyUpdate` throws (`Cannot read properties of undefined (reading 'id')`) with content lost. Rather than pin the precise throw location (brittle across versions), the test asserts `setThrew || syncThrew || contentLost`. This still fails loudly in the one case that matters: if a future yjs made re-parenting *safe*, all three go false and the "bind, never re-parent" API constraint would be flagged for review.
+- **U10 null is a Fable-boundary artifact.** A stored JS `null` is a real Y.Map value, but Fable collapses `YMap.get` → `'T option` so `null` reads back as `None`, indistinguishable from a missing key. Asserted null-presence via `.has` instead of `.Value`. The load-bearing U10 claim (Y.Map holds typed number/bool/string primitives, not only strings) is asserted directly.
+- **U7 pinned via `event.target` reference-equality, not `event.path`.** The Fable binding (`YEvent`) doesn't surface `path`; rather than reach for dynamic interop, the test proves the actual design consequence — a nested edit reaches the *single* root `observeDeep` and the deep event targets the nested type itself. The `.mjs` spike's path evidence (`["body"]`, `["list", 0]`) is noted in a comment.
 
 ### Step 2a — Differential harness
 

--- a/tests/Ylmish.Tests/Adaptive.Assumptions.fs
+++ b/tests/Ylmish.Tests/Adaptive.Assumptions.fs
@@ -1,0 +1,138 @@
+module Ylmish.Adaptive.Assumptions
+
+// Plan 0002, Step 1 — pin the FSharp.Data.Adaptive / Adaptify delta behaviour the
+// redesign depends on (assumption A1, lesson L1 in doc/plans/0002-ylmish-redesign.md).
+//
+// THE DECISIVE CHARACTERIZATION. The plan restricts `Encode.list` to VALUE
+// sequences (identity lives in `Encode.map` keys) precisely because Adaptify's
+// list deltas are POSITIONAL, not keyed. This file measures that and pins the
+// observed op counts so the finding can't silently drift under an Adaptify or
+// FSharp.Data.Adaptive upgrade.
+//
+// What the generated code does (common/Example.g.fs): an `IndexList<'T>` field
+// becomes a plain `clist`, and `Update` sets the WHOLE new IndexList. So the
+// emitted delta is whatever `ChangeableIndexList.Value <- new` computes by
+// comparing the two IndexLists by their `Index` keys:
+//   - derive the next list by STRUCTURAL ops (.Add/.Prepend/.RemoveAt) → Indices
+//     are preserved → minimal, identity-stable delta.
+//   - REBUILD from scratch (IndexList.ofList [...], the idiomatic
+//     `{ m with Items = recompute () }`) → every Index is fresh → positional
+//     value-rewrite (O(n)), and nested adaptive objects are rebound BY POSITION.
+//   - a REORDER has no identity-preserving form → always churns.
+//
+// Consequence in the plan: entities with identity belong in `Encode.map`
+// (HashMap → keyed amap reconcile), never in `Encode.list`.
+
+open FSharp.Data.Adaptive
+
+open Example
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+// -----------------------------------------------------------------------------
+// Measurement: drive an AdaptiveModel from one whole model to the next and count
+// the IndexListDelta operations emitted on the list field (PropD : IndexList<string>).
+// -----------------------------------------------------------------------------
+
+type private DeltaCount = { Sets : int; Removes : int } with
+    member c.Total = c.Sets + c.Removes
+
+let private mk (propD : IndexList<string>) : Model =
+    { PropA = ""; PropB = None; PropC = IndexList.empty
+      PropD = propD; PropE = { Prop0 = "" }; PropF = None }
+
+/// Count the delta PropD emits when the model goes from `before` to `after`.
+let private measurePropD (before : IndexList<string>) (after : IndexList<string>) : DeltaCount =
+    let am = AdaptiveModel.Create (mk before)
+    let reader = am.PropD.GetReader ()
+    // Prime: the first GetChanges reports the whole initial content; discard it so
+    // we measure only the incremental delta caused by the reassignment.
+    reader.GetChanges AdaptiveToken.Top |> ignore
+    transact (fun () -> am.Update (mk after))
+    let delta = reader.GetChanges AdaptiveToken.Top
+    let ops = delta |> IndexListDelta.toList
+    let sets = ops |> List.filter (fun (_, op) -> match op with Set _ -> true | _ -> false) |> List.length
+    let removes = ops |> List.filter (fun (_, op) -> match op with Remove -> true | _ -> false) |> List.length
+    { Sets = sets; Removes = removes }
+
+let private start = IndexList.ofList [ "a"; "b"; "c" ]
+
+let tests = testList "Adaptive.Assumptions (A1 / L1)" [
+
+    // ---- Identity-PRESERVING regime: structural ops on the previous IndexList.
+    // Here Adaptive earns its keep: each logical change is a minimal delta.
+
+    test "append via .Add preserves Index → 1 Set (minimal, identity-stable)" {
+        let c = measurePropD start (start.Add "d")
+        Expect.equal c { Sets = 1; Removes = 0 }
+            "appending one item touches exactly one Index — an O(1) delta"
+    }
+
+    test "prepend via .Prepend preserves Index → 1 Set (minimal, identity-stable)" {
+        let c = measurePropD start (start.Prepend "x")
+        Expect.equal c { Sets = 1; Removes = 0 }
+            "prepend is O(1): a/b/c keep their Indices, x gets a new one"
+    }
+
+    test "remove-middle via .RemoveAt preserves Index → 1 Remove (minimal)" {
+        let c = measurePropD start (start.RemoveAt 1)
+        Expect.equal c { Sets = 0; Removes = 1 }
+            "removing one item is an O(1) delta — only the dropped Index is touched"
+    }
+
+    // ---- Identity-DESTROYING regimes: rebuild-from-scratch and reorder. Here
+    // Adaptive degrades to positional value-rewrite — a list of entities would be
+    // corrupted (nested state rebound by position), which is why L1 bans it.
+
+    test "rebuild via IndexList.ofList (fresh Indices) → positional rewrite, NOT minimal" {
+        // The idiomatic `{ m with Items = recompute () }`: same logical prepend as
+        // the .Prepend case above, but a brand-new list with fresh Indices.
+        let after = IndexList.ofList [ "x"; "a"; "b"; "c" ]
+        let c = measurePropD start after
+        // computeDelta aligns POSITIONALLY: a prepend reads as pos0 a→x, pos1 b→a,
+        // pos2 c→b, pos3 +c. A logically-O(1) prepend costs O(n) value-rewrites and
+        // item identity is lost. (Ground truth captured/pinned in Step 1.)
+        Expect.equal (c.Sets, c.Removes) (4, 0)
+            "rebuild-from-scratch defeats Adaptive's diff: positional value-rewrite, not identity-stable"
+        Expect.isTrue (c.Total > 1) "not minimal"
+    }
+
+    test "reorder has NO identity-preserving form → churns (relevant to nested state)" {
+        // Reverse the list. No IndexList op *moves* an element keeping its Index, so
+        // a reorder is always fresh Indices.
+        let after = IndexList.ofList [ "c"; "b"; "a" ]
+        let c = measurePropD start after
+        Expect.equal (c.Sets, c.Removes) (2, 0)
+            "a reorder is positional value-churn, never an identity-preserving move"
+        Expect.isTrue (c.Total > 1) "not minimal"
+    }
+
+    // ---- Nested-state identity (PropC : IndexList<Submodel> → ChangeableModelList).
+    // Does a rebuilt list reuse the inner AdaptiveSubmodel objects (so a nested
+    // Y.Text/custom hung off an item would survive), or rebind them by position
+    // (orphaning state)? This is the exact hazard L1 protects against.
+
+    test "rebuilt list of submodels rebinds inner adaptive objects BY POSITION, not by id" {
+        let mkC (items : string list) : Model =
+            { PropA = ""; PropB = None
+              PropC = items |> List.map (fun p -> { Prop0 = p }) |> IndexList.ofList
+              PropD = IndexList.empty; PropE = { Prop0 = "" }; PropF = None }
+        let am = AdaptiveModel.Create (mkC [ "a"; "b" ])
+        // Capture the adaptive submodel object sitting at position 0.
+        let at0Before = am.PropC |> AList.force |> IndexList.toList |> List.item 0
+        // Prepend "x" by REBUILDING the list (fresh Indices) — the idiomatic update.
+        transact (fun () -> am.Update (mkC [ "x"; "a"; "b" ]))
+        let at0After = am.PropC |> AList.force |> IndexList.toList |> List.item 0
+        // ChangeableModelList reconciles by position: position 0's adaptive object is
+        // REUSED and updated in place from "a" to "x". The object that WAS item "a"
+        // now holds "x" — identity follows POSITION, not the item.
+        Expect.isTrue (System.Object.ReferenceEquals (at0Before, at0After))
+            "position 0's adaptive object is reused — a rebuilt list rebinds inner state to the new positional occupant"
+        Expect.equal (at0After.Prop0 |> AVal.force) "x"
+            "and it now holds the prepended item's value: item 'a's nested state was hijacked by 'x'"
+    }
+]

--- a/tests/Ylmish.Tests/Y.Assumptions.fs
+++ b/tests/Ylmish.Tests/Y.Assumptions.fs
@@ -1,0 +1,443 @@
+module Ylmish.Y.Assumptions
+
+// Plan 0002, Step 1 — pin the Yjs assumptions the redesign depends on.
+//
+// These characterization tests exercise RAW Yjs (no Ylmish production code) so
+// every "design consequence" claimed in doc/plans/0002-ylmish-redesign.md rests
+// on observed behaviour, not on docs. If a Yjs upgrade changes any of these
+// semantics, CI fails loudly and we revisit the design rather than shipping on a
+// stale assumption.
+//
+// The U-ids match the "Validated assumptions" table in the plan. Each test's
+// ground truth was captured by running doc/plans/0002-assumptions/*.mjs against
+// the pinned yjs (13.6.x). The load-bearing results:
+//   U2a  nested concurrent create clobbers wholesale  → create lazily, keyed
+//   U3   shared nested Y.Text interleaves & converges  → bind, never replace
+//   U3b  concurrent plain-string set is LWW            → the #83 failure mode
+//   U5b  re-parenting an integrated type corrupts       → API forbids it
+//   U6   transaction origins propagate with `local`    → origin echo-suppression
+//   U11  replacing a Y.Text drops concurrent edits     → why materialize can't merge
+//   U15  unknown keys survive an update exchange        → never delete foreign keys
+
+open Yjs
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+// `Y` is overloaded (the Yjs module, the exported Yjs class, and Ylmish.Y), so
+// spell the raw Yjs types out for annotations and casts.
+type private Doc = Yjs.Utils.Doc.Doc
+type private YText = Yjs.Types.YText.YText
+type private YMap<'a> = Yjs.Types.YMap.YMap<'a>
+type private YArray<'a> = Yjs.Types.YArray.YArray<'a>
+
+/// A doc with a deterministic clientID (real docs randomise it; concurrency
+/// tests need the tiebreak to be predictable — see U4).
+let private mkDoc (clientId : int) : Doc =
+    let d = Y.Doc.Create ()
+    d.clientID <- float clientId
+    d
+
+/// The unnamed root map (U1: `getMap()` is the root named "").
+let private root (d : Doc) : YMap<obj> = d.getMap ()
+
+/// Push all of `src`'s state into `dst` (one direction of a network round-trip).
+let private sync (src : Doc) (dst : Doc) =
+    Y.applyUpdate (dst, Y.encodeStateAsUpdate src)
+
+/// Exchange state in both directions until the two docs converge.
+let private syncBoth (a : Doc) (b : Doc) =
+    sync a b
+    sync b a
+
+let tests = testList "Y.Assumptions" [
+
+    // U1 — argless getMap is the stable root; every call returns the same instance.
+    // Consequence: root binding needs no consumer-named root.
+    testList "U1 root map identity" [
+        test "getMap() returns the same instance on repeated calls" {
+            let d = Y.Doc.Create ()
+            let m1 = root d
+            let m2 = root d
+            Expect.isTrue (System.Object.ReferenceEquals (m1, m2))
+                "getMap() must be idempotent — the root map is a stable binding target"
+        }
+    ]
+
+    // U2a — THE offline-create race. Two peers each create a fresh nested type
+    // under the SAME map key, then sync: one subtree wins WHOLESALE, the other's
+    // data is silently discarded. Consequence: never create containers eagerly;
+    // offline-creatable entities need consumer-supplied unique keys (Encode.map).
+    testList "U2a nested concurrent create clobbers wholesale" [
+        test "each peer creates its own Y.Array under the same key — one side is lost" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let a1 : YArray<obj> = Y.Array.Create ()
+            a1.push [| box "from-d1" |]
+            (root d1).set ("todos", box a1) |> ignore
+            let a2 : YArray<obj> = Y.Array.Create ()
+            a2.push [| box "from-d2" |]
+            (root d2).set ("todos", box a2) |> ignore
+
+            syncBoth d1 d2
+
+            let read (d : Doc) =
+                ((root d).get "todos").Value :?> YArray<obj>
+                |> fun a -> a.toArray () |> Seq.map (fun o -> unbox<string> o) |> Seq.toList
+            let s1 = read d1
+            let s2 = read d2
+            let hasD1 = List.contains "from-d1" s1
+            let hasD2 = List.contains "from-d2" s1
+            Expect.equal s1 s2 "docs must converge (CRDT guarantees agreement)"
+            Expect.isTrue (hasD1 || hasD2) "one peer's subtree survives"
+            Expect.isFalse (hasD1 && hasD2)
+                "U2a: nested concurrent create clobbers — both subtrees cannot survive"
+        }
+    ]
+
+    // U2b — the SAME race, but with root-level types (getArray by name): these
+    // merge by name, no wholesale loss. Consequence: root types are get-or-create
+    // safe; only nested-under-a-key creation races.
+    testList "U2b root-level types merge by name" [
+        test "two peers naming the same root array — both items survive" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            (d1.getArray "todos" : YArray<string>).push [| "from-d1" |]
+            (d2.getArray "todos" : YArray<string>).push [| "from-d2" |]
+
+            syncBoth d1 d2
+
+            let s1 = (d1.getArray "todos" : YArray<string>).toArray () |> Seq.toList
+            Expect.isTrue (List.contains "from-d1" s1 && List.contains "from-d2" s1)
+                "root types with the same name merge — no wholesale loss (contrast U2a)"
+        }
+    ]
+
+    // U3 — concurrent edits to ONE shared nested Y.Text (created once, then
+    // synced) interleave and converge. This is the whole point of the redesign.
+    testList "U3 shared nested Y.Text interleaves and converges" [
+        test "concurrent inserts on a shared Y.Text both survive" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let t = Y.Text.Create "hello"
+            (root d1).set ("body", box t) |> ignore
+            syncBoth d1 d2 // both now share the same text
+
+            ((root d1).get "body").Value :?> YText |> fun t -> t.insert (5, " world")
+            ((root d2).get "body").Value :?> YText |> fun t -> t.insert (0, "oh, ")
+            syncBoth d1 d2
+
+            let read (d : Doc) = (((root d).get "body").Value :?> YText).toString ()
+            let s1 = read d1
+            let s2 = read d2
+            Expect.equal s1 s2 "shared-text docs must converge"
+            Expect.isTrue (s1.Contains "world" && s1.Contains "oh, ")
+                "both peers' insertions survive on a shared nested Y.Text (interleaved, not clobbered)"
+        }
+    ]
+
+    // U3b — issue #83's failure mode. A string stored as a plain map value is an
+    // LWW register: concurrent sets clobber, one side's edit is lost.
+    testList "U3b concurrent plain-string set is LWW" [
+        test "two peers set the same key to different strings — one is lost" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            (root d1).set ("body", box "hello") |> ignore
+            syncBoth d1 d2
+            (root d1).set ("body", box "hello world") |> ignore
+            (root d2).set ("body", box "oh, hello") |> ignore
+            syncBoth d1 d2
+
+            let s1 = unbox<string> ((root d1).get "body").Value
+            let s2 = unbox<string> ((root d2).get "body").Value
+            Expect.equal s1 s2 "register converges"
+            Expect.isTrue (s1 = "hello world" || s1 = "oh, hello")
+                "exactly one concurrent set wins — a plain string is an LWW register (issue #83)"
+        }
+    ]
+
+    // U4 — the LWW winner is deterministic and order-independent: the HIGHER
+    // clientID wins, not wall-clock, not apply-order. Consequence: document "last
+    // writer" honestly as an arbitrary-but-convergent tiebreak.
+    testList "U4 LWW winner is the higher clientID" [
+        test "winner is order-independent and picks the higher clientID" {
+            for (c1, c2) in [ (1, 2); (2, 1); (100, 5) ] do
+                let d1 = mkDoc c1
+                let d2 = mkDoc c2
+                (root d1).set ("k", box ("v-from-" + string c1)) |> ignore
+                (root d2).set ("k", box ("v-from-" + string c2)) |> ignore
+                syncBoth d1 d2
+                let winner = unbox<string> ((root d1).get "k").Value
+                let loser = unbox<string> ((root d2).get "k").Value
+                Expect.equal winner loser "both docs agree on the winner"
+                Expect.equal winner ("v-from-" + string (max c1 c2))
+                    "the higher clientID wins — deterministic, not wall-clock"
+        }
+    ]
+
+    // U5b — re-parenting an already-integrated shared type CORRUPTS the doc: the
+    // call site may not throw, but a later sync throws and content is lost.
+    // Consequence: the public API must make re-parenting impossible by
+    // construction (bind each field to exactly one instance, never reuse).
+    testList "U5b re-parenting an integrated type corrupts the doc" [
+        test "re-setting an integrated Y.Text under another key breaks a later sync" {
+            let d1 = Y.Doc.Create ()
+            let t = Y.Text.Create "x"
+            (root d1).set ("a", box t) |> ignore
+
+            let mutable setThrew = false
+            try (root d1).set ("b", box t) |> ignore
+            with _ -> setThrew <- true
+
+            let mutable syncThrew = false
+            let d2 = Y.Doc.Create ()
+            try sync d1 d2
+            with _ -> syncThrew <- true
+
+            // Content survives ONLY if re-parenting were safe; here it is not.
+            let contentLost =
+                try
+                    let a = (root d2).get "a"
+                    match a with
+                    | Some v -> (v :?> YText).toString () <> "x"
+                    | None -> true
+                with _ -> true
+
+            Expect.isTrue (setThrew || syncThrew || contentLost)
+                "re-parenting an integrated type is unsafe: it throws or corrupts/loses content. \
+                 If this ever becomes safe, the 'bind, never re-parent' API constraint can be relaxed."
+        }
+    ]
+
+    // U6 — transaction origins propagate to observers with a correct `local`
+    // flag, and remote applyUpdate origins are visible with local=false.
+    // Consequence: echo suppression via a per-binding origin token (not booleans).
+    testList "U6 transaction origins propagate" [
+        test "explicit origin and remote-apply origin reach observers with local flags" {
+            let d1 = Y.Doc.Create ()
+            let seen = ResizeArray<obj option * bool> ()
+            (root d1).observe (fun _ (tr : Yjs.Utils.Transaction.Transaction) ->
+                seen.Add (tr.origin, tr.local))
+
+            d1.transact ((fun _ -> (root d1).set ("k", box 1) |> ignore), "my-origin")
+            (root d1).set ("k", box 2) |> ignore // no explicit origin
+            let d2 = Y.Doc.Create ()
+            (root d2).set ("k", box 3) |> ignore
+            Y.applyUpdate (d1, Y.encodeStateAsUpdate d2, "remote-origin")
+
+            Expect.equal seen.Count 3 "observer fires once per transaction"
+            let originStr (o : obj option) = match o with Some v -> unbox<string> v | None -> "<none>"
+            let (o0, l0) = seen.[0]
+            Expect.equal (originStr o0) "my-origin" "explicit transaction origin propagates"
+            Expect.isTrue l0 "a local transaction is flagged local=true"
+            let (o2, l2) = seen.[2]
+            Expect.equal (originStr o2) "remote-origin" "applyUpdate origin propagates"
+            Expect.isFalse l2 "a remote-applied transaction is flagged local=false"
+        }
+    ]
+
+    // U7 — one observeDeep on the root sees nested edits: editing a nested Y.Text
+    // fires the root's deep observer, and the event targets that nested type.
+    // Consequence: a single root observer covers the whole bound tree.
+    testList "U7 root observeDeep sees nested edits" [
+        test "a nested Y.Text edit fires the root's observeDeep, targeting the text" {
+            let d = Y.Doc.Create ()
+            let t = Y.Text.Create ""
+            (root d).set ("body", box t) |> ignore
+
+            let targets = ResizeArray<obj> ()
+            (root d).observeDeep (fun evts _ ->
+                for e in evts do targets.Add (box e.target))
+
+            t.insert (0, "hi")
+
+            Expect.isTrue (targets.Count > 0)
+                "editing a nested type must reach the single root observeDeep (paths e.g. [\"body\"] per the .mjs spike)"
+            Expect.isTrue (targets |> Seq.exists (fun o -> System.Object.ReferenceEquals (o, t)))
+                "the deep event targets the nested Y.Text itself — no per-child observer needed"
+        }
+    ]
+
+    // U8 — concurrent inserts into a shared Y.Array both survive, deterministic
+    // order. Consequence: lists merge; a safe default for value sequences.
+    testList "U8 concurrent array inserts both survive" [
+        test "two peers insert at the same position — both items survive" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let arr : YArray<obj> = Y.Array.Create ()
+            arr.push [| box "base" |]
+            (root d1).set ("xs", box arr) |> ignore
+            syncBoth d1 d2
+
+            (((root d1).get "xs").Value :?> YArray<obj>).insert (0, [| box "from-d1" |])
+            (((root d2).get "xs").Value :?> YArray<obj>).insert (0, [| box "from-d2" |])
+            syncBoth d1 d2
+
+            let read (d : Doc) =
+                (((root d).get "xs").Value :?> YArray<obj>).toArray ()
+                |> Seq.map (fun o -> unbox<string> o) |> Seq.toList
+            let s1 = read d1
+            Expect.equal (read d1) (read d2) "array docs converge"
+            Expect.isTrue (List.contains "from-d1" s1 && List.contains "from-d2" s1)
+                "both concurrent inserts survive"
+        }
+    ]
+
+    // U9 — deleting a nested item beats a concurrent edit inside it: the delete
+    // wins, the edit is lost. Documented, pinned limit.
+    testList "U9 delete beats concurrent edit-inside" [
+        test "one peer deletes an item while the other edits inside it — delete wins" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let item : YMap<obj> = Y.Map.Create ()
+            item.set ("title", box "a") |> ignore
+            let arr : YArray<obj> = Y.Array.Create ()
+            arr.push [| box item |]
+            (root d1).set ("xs", box arr) |> ignore
+            syncBoth d1 d2
+
+            (((root d1).get "xs").Value :?> YArray<obj>).delete (0, 1)               // d1 deletes
+            let item2 = (((root d2).get "xs").Value :?> YArray<obj>).get 0 :?> YMap<obj>
+            item2.set ("title", box "b") |> ignore                                    // d2 edits inside
+            syncBoth d1 d2
+
+            let len (d : Doc) =
+                (((root d).get "xs").Value :?> YArray<obj>).toArray () |> Seq.length
+            Expect.equal (len d1) 0 "deleted item stays deleted on d1"
+            Expect.equal (len d2) 0 "delete wins over the concurrent edit-inside on d2"
+        }
+    ]
+
+    // U10 — Y.Map holds any JSON primitive (number, bool, null, string, object,
+    // array), not only strings. Consequence: v2 elements carry typed primitives.
+    testList "U10 Y.Map holds typed primitives" [
+        test "number, bool, null and string round-trip through a Y.Map value" {
+            let d = Y.Doc.Create ()
+            let m = root d
+            m.set ("num", box 42) |> ignore
+            m.set ("bool", box true) |> ignore
+            m.set ("nul", null) |> ignore
+            m.set ("str", box "s") |> ignore
+            Expect.equal (unbox<int> (m.get "num").Value) 42 "number survives"
+            Expect.equal (unbox<bool> (m.get "bool").Value) true "bool survives"
+            Expect.equal (unbox<string> (m.get "str").Value) "s" "string survives"
+            // A stored null is a proper Y.Map value (JS distinguishes it from a
+            // missing key); Fable collapses it to `None` at the option boundary, so
+            // assert presence via `has` rather than reading `.Value`.
+            Expect.isTrue (m.has "nul") "null is a proper stored value, not a missing key"
+        }
+    ]
+
+    // U11 — replacing a nested Y.Text with a fresh instance wins over a peer's
+    // concurrent edit to the OLD text; the peer's edit is lost. This is exactly
+    // why materialize-per-update can never merge. Consequence: bind, never replace.
+    testList "U11 replacing a Y.Text drops concurrent edits" [
+        test "replacement wins; a concurrent edit of the old text is lost" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let t1 = Y.Text.Create ""
+            t1.insert (0, "v1")
+            (root d1).set ("body", box t1) |> ignore
+            syncBoth d1 d2
+            let t2ref = ((root d2).get "body").Value :?> YText
+
+            let tNew = Y.Text.Create ""
+            tNew.insert (0, "v2")
+            (root d1).set ("body", box tNew) |> ignore // d1 REPLACES the text
+            t2ref.insert (2, "!")                       // d2 edits the OLD text
+            syncBoth d1 d2
+
+            let read (d : Doc) = (((root d).get "body").Value :?> YText).toString ()
+            let s1 = read d1
+            Expect.equal (read d1) (read d2) "docs converge"
+            Expect.isTrue (s1.Contains "v2") "the replacement wins"
+            Expect.isFalse (s1.Contains "!") "the concurrent edit of the replaced text is lost"
+        }
+    ]
+
+    // U13 — a concurrent "move" (delete+insert) of the same item duplicates it.
+    // Consequence: prefer keyed-map + order-field over structural moves.
+    testList "U13 concurrent move duplicates the item" [
+        test "both peers move the same item to the end — it appears twice" {
+            let d1 = mkDoc 1
+            let d2 = mkDoc 2
+            let arr : YArray<obj> = Y.Array.Create ()
+            arr.push [| box "a"; box "b"; box "c" |]
+            (root d1).set ("xs", box arr) |> ignore
+            syncBoth d1 d2
+
+            let move (d : Doc) =
+                let xs = ((root d).get "xs").Value :?> YArray<obj>
+                d.transact (fun _ ->
+                    let v = xs.get 0
+                    xs.delete (0, 1)
+                    xs.push [| v |])
+            move d1
+            move d2
+            syncBoth d1 d2
+
+            let read (d : Doc) =
+                (((root d).get "xs").Value :?> YArray<obj>).toArray ()
+                |> Seq.map (fun o -> unbox<string> o) |> Seq.toList
+            let s1 = read d1
+            Expect.equal (read d1) (read d2) "docs converge"
+            Expect.equal (s1 |> List.filter ((=) "a") |> List.length) 2
+                "the concurrently-moved item is duplicated (Yjs v13 structural-move limit)"
+        }
+    ]
+
+    // U14 — a single doc.transact spanning many nested types produces exactly ONE
+    // observeDeep batch. Consequence: a remote transaction is one Elmish Set.
+    testList "U14 one transaction is one observeDeep batch" [
+        test "a transact touching text, array and a map key fires one deep batch" {
+            let d = Y.Doc.Create ()
+            let t = Y.Text.Create ""
+            let a : YArray<obj> = Y.Array.Create ()
+            (root d).set ("t", box t) |> ignore
+            (root d).set ("a", box a) |> ignore
+
+            let mutable batches = 0
+            let mutable evtsTotal = 0
+            (root d).observeDeep (fun evts _ ->
+                batches <- batches + 1
+                evtsTotal <- evtsTotal + evts.Count)
+
+            d.transact (fun _ ->
+                t.insert (0, "hi")
+                a.push [| box 1 |]
+                (root d).set ("k", box "v") |> ignore)
+
+            Expect.equal batches 1 "one transaction yields one observeDeep batch (⇒ one Elmish Set)"
+            Expect.isTrue (evtsTotal > 0) "the batch carries the per-type events"
+        }
+    ]
+
+    // U15 — applying an update carrying keys a client doesn't understand is clean:
+    // unknown keys are preserved and readable. Consequence: forward compatibility
+    // is free IF the runtime stops deleting unknown keys (foundation for migration).
+    testList "U15 unknown keys survive an update exchange" [
+        test "an old client applies an update adding an unknown key without loss" {
+            let oldc = Y.Doc.Create ()
+            let newc = Y.Doc.Create ()
+            (root oldc).set ("v1", box "old-data") |> ignore
+            syncBoth oldc newc
+
+            let t = Y.Text.Create ""
+            t.insert (0, "new-data")
+            (root newc).set ("v2", box t) |> ignore // a key the old client never knew
+
+            let mutable threw = false
+            try syncBoth oldc newc
+            with _ -> threw <- true
+
+            Expect.isFalse threw "applying an update with unknown keys must not throw"
+            Expect.equal (unbox<string> ((root oldc).get "v1").Value) "old-data"
+                "the old client's own data is untouched"
+            Expect.isTrue ((root oldc).has "v2")
+                "the unknown key is preserved and readable (foundation for schema migration)"
+        }
+    ]
+]

--- a/tests/Ylmish.Tests/Ylmish.Tests.fs
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fs
@@ -4,12 +4,14 @@ open Ylmish
 
 let tests = [
    Adaptive.Codec.tests
+   Adaptive.Assumptions.tests
    Y.Delta.tests
    Y.Text.tests
    Y.Array.tests
    Y.Map.tests
    Y.Element.tests
    Y.Doc.tests
+   Y.Assumptions.tests
    Program.tests
    TodoCollaborative.tests
 ]

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -9,12 +9,14 @@
     <Compile Include="common\Example.g.fs" />
     <Compile Include="common\Elmish.fs" />
     <Compile Include="Adaptive.Codec.fs" />
+    <Compile Include="Adaptive.Assumptions.fs" />
     <Compile Include="Y.Delta.fs" />
     <Compile Include="Y.Text.fs" />
     <Compile Include="Y.Array.fs" />
     <Compile Include="Y.Map.fs" />
     <Compile Include="Y.Element.fs" />
     <Compile Include="Y.Doc.fs" />
+    <Compile Include="Y.Assumptions.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="TodoCollaborative.fs" />
     <Compile Include="Ylmish.Tests.fs" />


### PR DESCRIPTION
No code changes. Establish the toolchain and record the baseline test
count per the plan's check-in ritual: npm test → 99 passing, 0 pending,
0 failing.

Tick Step 0 in Progress and add a Decisions & lessons note covering the
.NET SDK install, the benign NU1608 restore warning, and the skim of
Y.fs / Adaptive.Codec.fs / Program.fs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J4ypsiNoUF7uU18z3qtCdq