### PR TITLE
Disable automatic workflow triggers, require manual dispatch

### DIFF
--- a/.github/workflows/continue-work.lock.yml
+++ b/.github/workflows/continue-work.lock.yml
@@ -25,10 +25,9 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9dc45b0994e555721b71d6364d14b400d9cd925be0d70a44c035499479fe22a3","compiler_version":"v0.66.1","strict":true,"agent_id":"claude"}
 
 name: "Continue Work: Assign Claude to Next Task"
+# Disabled: automatic issue-closed trigger replaced with manual-only dispatch.
 "on":
-  issues:
-    types:
-    - closed
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/continue-work.md
+++ b/.github/workflows/continue-work.md
@@ -1,9 +1,11 @@
 ---
 description: Continue work by assigning Claude to the next issue when a task is completed
 engine: claude
+# Starting work from GitHub issues is disabled. The automatic issue-closed
+# trigger has been replaced with manual-only dispatch so this workflow no longer
+# assigns agents to the next issue on its own.
 on:
-  issues:
-    types: [closed]
+  workflow_dispatch:
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/plan-issues.lock.yml
+++ b/.github/workflows/plan-issues.lock.yml
@@ -25,12 +25,9 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9043e15f1e80b1f5204ff7e9311c4ef491c71e53e15154afeba7df3d56aa044c","compiler_version":"v0.66.1","strict":true,"agent_id":"claude"}
 
 name: "Break Down Plan Objectives into GitHub Issues"
+# Disabled: automatic push-to-master trigger replaced with manual-only dispatch.
 "on":
-  push:
-    branches:
-    - master
-    paths:
-    - doc/plans/**
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/plan-issues.md
+++ b/.github/workflows/plan-issues.md
@@ -1,12 +1,11 @@
 ---
 description: Break down plan objectives into agent-sized GitHub issues
 engine: claude
+# Starting work from GitHub issues is disabled. The automatic push-to-master
+# trigger has been replaced with manual-only dispatch so this workflow no longer
+# breaks plans into issues or assigns agents on its own.
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'doc/plans/**'
+  workflow_dispatch:
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: publish
 
+# Publishing to NuGet is disabled. The automatic push-to-master trigger has been
+# replaced with manual-only dispatch so this workflow never publishes on its own.
 on:
-  push:
-    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
This change disables automatic triggers for three GitHub workflows and replaces them with manual-only dispatch. This prevents workflows from running automatically based on repository events.

## Key Changes
- **plan-issues workflow**: Replaced automatic `push` trigger (on changes to `doc/plans/**`) with `workflow_dispatch` for manual triggering only
- **continue-work workflow**: Replaced automatic `issues` trigger (on issue closed events) with `workflow_dispatch` for manual triggering only
- **publish workflow**: Replaced automatic `push` trigger (on master branch) with `workflow_dispatch` for manual triggering only

## Implementation Details
- Added explanatory comments to each workflow file documenting why the automatic triggers were disabled
- All three workflows now use `workflow_dispatch` as their sole trigger mechanism
- No changes to workflow logic, permissions, or job definitions—only the trigger configuration was modified
- Lock files were updated to reflect the trigger changes in the compiled workflow definitions

https://claude.ai/code/session_01Y5vBL8bFAPgV4m1WTKuNH4