### PR TITLE
Plan 0002 Steps 2a + 2b: differential harness and target API skeleton

### DIFF
--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -309,7 +309,7 @@ For the engineer executing this (competent F#, new to this codebase):
 
 - [x] Step 0 — Baseline (S) — 99 passing, 0 skipped
 - [x] Step 1 — Pin the assumptions (M) — 125 passing (+16 Y.Assumptions, +10 Adaptive.Assumptions)
-- [ ] Step 2a — Differential harness (M)
+- [x] Step 2a — Differential harness (M) — 130 passing (+5 calibration)
 - [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
 - [ ] Step 3 — `Ylmish.Text` (M)
 - [ ] Step 4 — Codec v2 (L; sub-steps 4a–4e)
@@ -357,6 +357,13 @@ Calibrate it — this is the step's real deliverable: **green on the oracle** (g
 *Acceptance:* the three calibration results above, as committed tests (the materialize-red one marked as expected-fail/pending so the suite stays green).
 
 *Check-in:* test count; the calibration triad's output; the harness's public surface (it will be reused in Steps 5, 7, 9).
+
+*Decisions & lessons (executed 2026-07-04):*
+
+- 130 passing (+5). `tests/Ylmish.Tests/Harness.fs`, adapted from the reference branch's `Harness.fs` per the quarry note — the design transfers wholesale (Bridge / schedule driver / differential vs raw-Yjs oracle / minimality meter).
+- Public surface for reuse: `Bridge`/`BridgeFactory` (whole models in, converged model out), `run : BridgeFactory -> Delivery -> ReplicaOp list -> RunResult` with `Immediate`/`Concurrent` delivery, `differential` (SUT vs oracle, reports `Lost` ids), `incrementalBytes`/`measureApplies` (O(delta)-vs-O(state) meter, calibrated now, first *used* in Step 5).
+- **Interpretation surfaced:** the plan said the materialize-red calibration lands "as expected-fail/pending". A pending test asserts nothing, so instead it lands as a *passing* test that asserts the mismatch and the lost id (`MatchesOracle = false`, `Lost` non-empty) — a stronger pin with the same green suite. When Step 5 fixes the bug this test fails by design and gets flipped into the fix's regression test; its message says so.
+- The driver models `withYlmish`'s remote-update → read-back → `Set` loop on every delivery (refresh the receiving replica's model from its bridge before its next local op). Without this the old path would fail even sequentially and the harness would be hostile rather than discriminating.
 
 ### Step 2b — Target API skeleton + north stars (red) — **design-review checkpoint**
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -228,19 +228,31 @@ module Ylmish.Codec.Value
 type Encoder<'a>        // opaque: 'a → JSON primitive
 type Decoder<'a>        // opaque: JSON primitive → 'a, with path-tracked errors
 
-val string : Encoder<string>          val int    : Encoder<int>
-val float  : Encoder<float>           val bool   : Encoder<bool>
-// domain types ride a primitive by mapping, staying inside the sub-language:
-val contramap : ('b -> 'a) -> Encoder<'a> -> Encoder<'b>   // e.g. TodoId → string
-val map       : ('a -> 'b) -> Decoder<'a> -> Decoder<'b>
+module Encode =         // Value.Encode.string, Value.Encode.int, …
+    val string : Encoder<string>      val int  : Encoder<int>
+    val float  : Encoder<float>       val bool : Encoder<bool>
+    // domain types ride a primitive by mapping, staying inside the sub-language:
+    val contramap : ('b -> 'a) -> Encoder<'a> -> Encoder<'b>   // e.g. TodoId → string
+
+module Decode =         // Value.Decode.string, …
+    val string : Decoder<string>      val int  : Decoder<int>
+    val float  : Decoder<float>       val bool : Decoder<bool>
+    val map : ('a -> 'b) -> Decoder<'a> -> Decoder<'b>
 ```
 
-The register combinators are then sugar over the same sub-language (`Encode.bool = Encode.value Value.bool`), and the codec has exactly one notion of "primitive" shared by registers and list items:
+(Encoders and decoders live in `Value.Encode`/`Value.Decode` submodules so both sides can use the plain primitive names — confirmed with Nick at the 2b review.)
+
+The register combinators are then sugar over the same sub-language (`Encode.bool = Encode.value Value.Encode.bool`), the codec has exactly one notion of "primitive" shared by registers and list items, and **optionality composes by name** over any single-`aval` encoding — `None` is key-absence, never null:
 
 ```fsharp
-val Encode.value : Value.Encoder<'a> -> aval<'a>  -> Encoded
-val Encode.list  : Value.Encoder<'a> -> alist<'a> -> Encoded
-val Decode.list  : Value.Decoder<'a> -> Decoder<_, _, IndexList<'a>>
+val Encode.value  : Value.Encoder<'a> -> aval<'a>  -> Encoded
+val Encode.list   : Value.Encoder<'a> -> alist<'a> -> Encoded
+val Encode.option : (aval<'a> -> Encoded) -> aval<'a option> -> Encoded
+// e.g. Encode.option Encode.text m.Note — an optional collaborative text.
+// None→Some creates the backing type lazily (a local edit); Some→None deletes
+// the key (delete beats concurrent inner edits, U9). Collections have no aval
+// view; an empty map/list is their "none".
+val Decode.list   : Value.Decoder<'a> -> Decoder<'model, IndexList<'a>>
 ```
 
 Ordering of keyed items is the consumer's policy: an immutable key names the item, a mutable order field (e.g. fractional index) sorts it — never the reverse (L7). `recipes.md` shows the pattern.
@@ -377,11 +389,11 @@ Then write the north-star tests against that surface, `ptestCase`-skipped: concu
 
 *Decisions & lessons (executed 2026-07-04):* 130 passing + 3 pending (the north stars). New files: `src/Ylmish/Text.fs`, `src/Ylmish/Codec.fs`, `Ylmish.Program.V2` (appended to `Program.fs`), `tests/Ylmish.Tests/NorthStar.fs`. Interpretations made where the plan's sketches were ambiguous — **each is a review point, none is defended**:
 
-1. **`Value.Encode.*` / `Value.Decode.*` submodules**, not the sketch's flat `Value.string` — one module can't hold an encoder and a decoder both named `string`. Cost: `Encode.list Value.Encode.string …` reads long; alternatives (flat encoders + `Value.Of.string` decoders, or paired `Value.string : Encoder * Decoder`) trade symmetry for brevity.
+1. **`Value.Encode.*` / `Value.Decode.*` submodules**, not the sketch's flat `Value.string` — one module can't hold an encoder and a decoder both named `string`. **Resolved with Nick (2b review): the submodule shape is confirmed**; the design-section sketch was updated to match.
 2. **`Ylmish.Program.V2`** nests the new options record + `withYlmish` so the running v1 stays untouched; Step 7 deletes v1 and promotes these names. Scaffolding, not the final shape.
 3. **No `aval` anywhere in the v2 surface**: `Decoder<'model,'a>` is opaque and `Decode.run : 'model -> Decoder<'model,'r> -> Y.Doc -> Result<'r, Error list>` is synchronous — v1's `Decoded<'a> = Validation aval` is gone; liveness (when to re-decode) is the runtime's concern (Step 6). This is the dependency-posture decision applied literally.
 4. **`OnError` is a record** `{ Handle : Error list -> unit }`, not a single-case union — a case named like its type shadows the companion module (`OnError.log` resolved to the case constructor, found empirically).
-5. **`Encode.option : ('a -> Encoded) -> aval<'a option> -> Encoded` is the roughest edge.** The inner encoder receives a plain `'a`, not an adaptive view — fine for registers, wrong for `Text option` (the inner text couldn't stay live). Options over collaborative types may need a different shape (or a rule: `option` wraps Value-sub-language registers only, enforced like L1). Flagged for the review.
+5. **`Encode.option` — resolved with Nick (2b review): the inner encoder takes the adaptive view.** `Encode.option : (aval<'a> -> Encoded) -> aval<'a option> -> Encoded`, so optionality composes by name with every single-`aval` combinator (`Encode.option Encode.text m.Note`) and the decode side is already presence-based (`Decode.object.optional "note" Decode.text : Decoder<_, Text option>` — the symmetry falls out). Semantics documented on the combinator: None = key absent (never null); None→Some creates lazily at the transition; Some→None deletes, delete-beats-inner-edits (U9); concurrent initialization of the same optional field is the accepted first-create limitation. **New named risk for Step 5:** the runtime needs a "Some-window" adaptive projection (an inner `aval<'a>` live only while the option is Some) — no FSharp.Data.Adaptive built-in does this; budget for building and testing it. The north stars now exercise a `Note : Text option` field as consumer code.
 6. **Composition combinators are inert stubs; only runtime entry points throw.** Found empirically: a consumer's module-level `let decode = Decode.object { … }` evaluates the builder at module load, so throwing stubs crashed the suite before any test ran. The final implementation inherits this constraint: composing a codec must be total and cheap; effects live in `run`/attach.
 7. **The `Ylmish.Codec` namespace shadows v1's `Codec.` references in `Y.fs`** (the interim-compatibility rule bit at 2b, earlier than Step 4 predicted) — fixed with a `module V1 = Ylmish.Adaptive.Codec` alias in the materialize path, which Step 7 deletes anyway.
 8. **North stars use a hand-written adaptive companion**, not Adaptify — 2b must not take on codegen risk; Step 3 owns proving `[<ModelType>]` with a `Text` field.
@@ -423,7 +435,7 @@ Internal `Binding.attach doc encoded : IDisposable` — the eventual replacement
 - **5f** — custom dispatch through `BindContext`;
 - **5g** — composition (a model using every kind at once).
 
-*Tests first (behavioural contract, two-doc via the Step 2a harness where relevant):* lazy container creation in one transaction; adopt-never-replace (the U11 anti-test); untouched unknown keys; kind-drift structured error (L5); all writes transacted under the origin token (L4); O(delta) op counts via `doc.on("update")` for the keyed/list/text paths.
+*Tests first (behavioural contract, two-doc via the Step 2a harness where relevant):* lazy container creation in one transaction; adopt-never-replace (the U11 anti-test); untouched unknown keys; kind-drift structured error (L5); all writes transacted under the origin token (L4); O(delta) op counts via `doc.on("update")` for the keyed/list/text paths; **option transitions** — None→Some creates the backing type lazily, Some→None deletes the key, and the inner encoding stays live across the Some window (this requires the "Some-window" adaptive projection named at the 2b check-in — a new internal primitive, test it in isolation first).
 
 *Acceptance:* the harness's differential runner passes on every sub-step's slice **where the old materialize path failed its calibration** — same schedules, new result; old path untouched and old suite green.
 

--- a/doc/plans/0002-ylmish-redesign.md
+++ b/doc/plans/0002-ylmish-redesign.md
@@ -310,7 +310,7 @@ For the engineer executing this (competent F#, new to this codebase):
 - [x] Step 0 — Baseline (S) — 99 passing, 0 skipped
 - [x] Step 1 — Pin the assumptions (M) — 125 passing (+16 Y.Assumptions, +10 Adaptive.Assumptions)
 - [x] Step 2a — Differential harness (M) — 130 passing (+5 calibration)
-- [ ] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**)
+- [x] Step 2b — Target API skeleton + north stars (M — **design-review checkpoint**) — 130 passing, 3 pending (the north stars, skipped until Step 7) — **awaiting Nick's signature review**
 - [ ] Step 3 — `Ylmish.Text` (M)
 - [ ] Step 4 — Codec v2 (L; sub-steps 4a–4e)
 - [ ] Step 5 — Binding, encode direction (L; sub-steps 5a–5g)
@@ -374,6 +374,18 @@ Then write the north-star tests against that surface, `ptestCase`-skipped: concu
 *Acceptance:* everything compiles; north stars are skipped; **no implementation**.
 
 *Check-in:* this is the one to slow down on — the diff *is* the public API. Nick reviews the signatures here, before any implementation exists to defend. Surface every place the sketches in this document were ambiguous and what you chose.
+
+*Decisions & lessons (executed 2026-07-04):* 130 passing + 3 pending (the north stars). New files: `src/Ylmish/Text.fs`, `src/Ylmish/Codec.fs`, `Ylmish.Program.V2` (appended to `Program.fs`), `tests/Ylmish.Tests/NorthStar.fs`. Interpretations made where the plan's sketches were ambiguous — **each is a review point, none is defended**:
+
+1. **`Value.Encode.*` / `Value.Decode.*` submodules**, not the sketch's flat `Value.string` — one module can't hold an encoder and a decoder both named `string`. Cost: `Encode.list Value.Encode.string …` reads long; alternatives (flat encoders + `Value.Of.string` decoders, or paired `Value.string : Encoder * Decoder`) trade symmetry for brevity.
+2. **`Ylmish.Program.V2`** nests the new options record + `withYlmish` so the running v1 stays untouched; Step 7 deletes v1 and promotes these names. Scaffolding, not the final shape.
+3. **No `aval` anywhere in the v2 surface**: `Decoder<'model,'a>` is opaque and `Decode.run : 'model -> Decoder<'model,'r> -> Y.Doc -> Result<'r, Error list>` is synchronous — v1's `Decoded<'a> = Validation aval` is gone; liveness (when to re-decode) is the runtime's concern (Step 6). This is the dependency-posture decision applied literally.
+4. **`OnError` is a record** `{ Handle : Error list -> unit }`, not a single-case union — a case named like its type shadows the companion module (`OnError.log` resolved to the case constructor, found empirically).
+5. **`Encode.option : ('a -> Encoded) -> aval<'a option> -> Encoded` is the roughest edge.** The inner encoder receives a plain `'a`, not an adaptive view — fine for registers, wrong for `Text option` (the inner text couldn't stay live). Options over collaborative types may need a different shape (or a rule: `option` wraps Value-sub-language registers only, enforced like L1). Flagged for the review.
+6. **Composition combinators are inert stubs; only runtime entry points throw.** Found empirically: a consumer's module-level `let decode = Decode.object { … }` evaluates the builder at module load, so throwing stubs crashed the suite before any test ran. The final implementation inherits this constraint: composing a codec must be total and cheap; effects live in `run`/attach.
+7. **The `Ylmish.Codec` namespace shadows v1's `Codec.` references in `Y.fs`** (the interim-compatibility rule bit at 2b, earlier than Step 4 predicted) — fixed with a `module V1 = Ylmish.Adaptive.Codec` alias in the materialize path, which Step 7 deletes anyway.
+8. **North stars use a hand-written adaptive companion**, not Adaptify — 2b must not take on codegen risk; Step 3 owns proving `[<ModelType>]` with a `Text` field.
+9. `Error` is a fresh minimal union (`UnexpectedKind`/`UnexpectedValue`/`MissingProperty` over a `Path` that gains a `MapKey` segment) — independent of v1's, since v1 dies at Step 7.
 
 ### Step 3 — `Ylmish.Text`
 

--- a/src/Ylmish/Codec.fs
+++ b/src/Ylmish/Codec.fs
@@ -1,0 +1,216 @@
+namespace Ylmish.Codec
+
+// Plan 0002, Step 2b — target API skeleton for the v2 codec. Signatures are
+// the deliverable (this is the design-review checkpoint); bodies are stubs
+// until Step 4. The v1 codec (Ylmish.Adaptive.Codec) stays untouched and
+// running until Step 7. See doc/plans/0002-ylmish-redesign.md ("The codec, v2").
+//
+// The taxonomy — the model's type is the merge choice:
+//
+//   Text                     Encode.text    → Y.Text     splices interleave
+//   bool/int/float/string    Encode.bool/…  → map entry  LWW register
+//   record                   Encode.object  → Y.Map      per-key merge
+//   HashMap<string,'T>       Encode.map     → Y.Map      element-wise by key
+//   IndexList<'v> (values)   Encode.list    → Y.Array    insert/delete merge
+//   any subtree              Encode.atomic  → one value  wholesale LWW
+//   anything                 Encode.custom  → your type  consumer-defined
+
+open FSharp.Data.Adaptive
+open Yjs
+
+open Ylmish
+
+// -----------------------------------------------------------------------------
+// The Value sub-language — incorrect by construction (design inputs / L1).
+// Positions that can only hold JSON primitives (list items, registers) take
+// these opaque types, constructible ONLY from the primitives below. There is no
+// injection from Encoded, so "a list of texts" or "a list of objects" is a type
+// error at the call site, and the fix (Encode.map) is visible in the signature
+// you reach for instead.
+// -----------------------------------------------------------------------------
+
+module Value =
+
+    type Encoder<'a> = private | EncoderStub
+    type Decoder<'a> = private | DecoderStub
+
+    [<RequireQualifiedAccess>]
+    module Encode =
+        let string : Encoder<string> = EncoderStub
+        let int : Encoder<int> = EncoderStub
+        let float : Encoder<float> = EncoderStub
+        let bool : Encoder<bool> = EncoderStub
+        /// Domain types ride a primitive by mapping into it, staying inside the
+        /// sub-language: `Value.Encode.contramap TodoId.value Value.Encode.string`.
+        let contramap (f : 'b -> 'a) (encoder : Encoder<'a>) : Encoder<'b> = EncoderStub
+
+    [<RequireQualifiedAccess>]
+    module Decode =
+        let string : Decoder<string> = DecoderStub
+        let int : Decoder<int> = DecoderStub
+        let float : Decoder<float> = DecoderStub
+        let bool : Decoder<bool> = DecoderStub
+        let map (f : 'a -> 'b) (decoder : Decoder<'a>) : Decoder<'b> = DecoderStub
+
+// -----------------------------------------------------------------------------
+// Errors — path-tracked, so a decode failure names where it happened.
+// -----------------------------------------------------------------------------
+
+type PathSegment =
+    | ObjectKey of string
+    | MapKey of string
+    | ArrayIndex of int
+
+type Path = PathSegment list
+
+type Error =
+    /// The doc holds a different kind at this path than the decoder expects —
+    /// including schema drift against an existing Y type (L5).
+    | UnexpectedKind of path : Path * message : string
+    | UnexpectedValue of path : Path * message : string
+    | MissingProperty of path : Path
+
+// -----------------------------------------------------------------------------
+// Core types. Encoded is an opaque description of "which shared type backs each
+// field" — the binding layer walks it (Step 5); consumers only compose it.
+// Decoder is a Reader over (current model, decoded position): `Decode.ask`
+// returns the current model so app-only fields survive remote updates.
+// Unlike v1 there is no aval in the public surface — liveness is the runtime's
+// concern (dependency posture: Adaptive trends toward encapsulation).
+// -----------------------------------------------------------------------------
+
+type Encoded = private | EncodedStub
+
+type Decoder<'model, 'a> = private | DecoderStub
+
+// -----------------------------------------------------------------------------
+// Custom elements — the escape hatch (public by decision; Fable.Yjs types on
+// purpose so a consumer can hand a real Y.Text to an editor binding).
+// -----------------------------------------------------------------------------
+
+/// Handed to a CustomElement's Connect. Get-or-creates this element's slot in
+/// the doc as a given Y type; the binding layer guarantees the instance is
+/// integrated exactly once (U5) and adopted, never replaced (U11).
+type BindContext =
+    { GetText : unit -> Y.Text
+      GetMap : unit -> Y.Map<obj>
+      GetArray : unit -> Y.Array<obj>
+      /// The origin token local writes must be transacted under — echo
+      /// suppression (U6), and the seam Y.UndoManager integration would use.
+      Origin : obj }
+
+/// A consumer-defined merge strategy. Implementations push local model changes
+/// into their Y type inside `doc.transact(_, ctx.Origin)` and keep `Value`
+/// current; remote changes surface through the same root observeDeep as
+/// everything else (no Subscribe needed under bind-in-place — L6).
+type CustomElement =
+    abstract Connect : BindContext -> System.IDisposable
+    /// Current merged value, read at decode time. Boxed: Decode.custom unboxes
+    /// under the consumer's type.
+    abstract Value : obj
+
+// -----------------------------------------------------------------------------
+// Encoders — one word per field is the merge choice.
+// -----------------------------------------------------------------------------
+
+[<RequireQualifiedAccess>]
+module Encode =
+    // Step 2b: combinators are INERT stubs — composition (including module-level
+    // codec values) must be safe before Step 4; only the runtime entry points throw.
+
+    /// A record: per-key merge of whatever each field chose.
+    let object (props : (string * Encoded) list) : Encoded = EncodedStub
+
+    /// An LWW register holding a Value-sub-language primitive.
+    let value (encoder : Value.Encoder<'a>) (a : aval<'a>) : Encoded = EncodedStub
+
+    // Sugar over `value` — the codec has exactly one notion of "primitive".
+    let string (a : aval<string>) : Encoded = EncodedStub
+    let int (a : aval<int>) : Encoded = EncodedStub
+    let float (a : aval<float>) : Encoded = EncodedStub
+    let bool (a : aval<bool>) : Encoded = EncodedStub
+
+    /// Collaboratively-edited text, backed by a Y.Text: splices interleave.
+    let text (a : aval<Text>) : Encoded = EncodedStub
+
+    /// The keyed-collection primitive: element-wise merge by the map key.
+    /// Different items never conflict; per-item fields merge per their own
+    /// encodings; the shape for anything creatable offline (app-minted keys).
+    let map (encodeItem : 'v -> Encoded) (items : amap<string, 'v>) : Encoded = EncodedStub
+
+    /// A sequence of VALUES (insert/delete merge, diff-reconciled). Items are
+    /// Value-sub-language primitives by construction — entities with identity
+    /// belong in `map` (L1).
+    let list (encodeItem : Value.Encoder<'a>) (items : alist<'a>) : Encoded = EncodedStub
+
+    /// Presence/absence of any encoded position. None = the key is absent —
+    /// never null (a stored null is unreadable through the Fable binding's
+    /// `get`, see the Step 1 lesson).
+    let option (encodeSome : 'a -> Encoded) (a : aval<'a option>) : Encoded = EncodedStub
+
+    /// Deliberate wholesale-LWW replacement of an entire subtree (L8).
+    let atomic (encoded : Encoded) : Encoded = EncodedStub
+
+    /// The escape hatch: a consumer-defined merge strategy over a real Y type.
+    let custom (element : CustomElement) : Encoded = EncodedStub
+
+// -----------------------------------------------------------------------------
+// Decoders — a computation expression mirroring v1's ergonomics, minus the
+// exposed aval. `Decode.run` is synchronous: model + decoder + doc state in,
+// Result out; the runtime drives it on remote transactions (Step 6).
+// -----------------------------------------------------------------------------
+
+[<RequireQualifiedAccess>]
+module Decode =
+    // Step 2b: combinators are INERT stubs (see Encode); only `run` throws.
+
+    /// The current model, from the Reader environment — how app-only fields
+    /// survive remote updates and how decode-empty-=-init falls out.
+    [<GeneralizableValue>]
+    let ask<'model> : Decoder<'model, 'model> = DecoderStub
+
+    [<GeneralizableValue>]
+    let text<'model> : Decoder<'model, Text> = DecoderStub
+
+    /// A Value-sub-language primitive out of an LWW register.
+    let value (decoder : Value.Decoder<'a>) : Decoder<'model, 'a> = DecoderStub
+
+    [<GeneralizableValue>]
+    let string<'model> : Decoder<'model, string> = DecoderStub
+    [<GeneralizableValue>]
+    let int<'model> : Decoder<'model, int> = DecoderStub
+    [<GeneralizableValue>]
+    let float<'model> : Decoder<'model, float> = DecoderStub
+    [<GeneralizableValue>]
+    let bool<'model> : Decoder<'model, bool> = DecoderStub
+
+    let map (decodeItem : Decoder<'model, 'i>) : Decoder<'model, HashMap<string, 'i>> = DecoderStub
+
+    let list (decodeItem : Value.Decoder<'a>) : Decoder<'model, IndexList<'a>> = DecoderStub
+
+    /// Decodes the subtree the way `Encode.atomic` wrote it: as one value.
+    let atomic (decodeInner : Decoder<'model, 'a>) : Decoder<'model, 'a> = DecoderStub
+
+    /// Reads the CustomElement's merged `Value`, unboxed under 'a.
+    [<GeneralizableValue>]
+    let custom<'model, 'a> : Decoder<'model, 'a> = DecoderStub
+
+    /// Run a decoder against the doc's current state. Total: errors are
+    /// path-tracked values, not exceptions.
+    let run (model : 'model) (decoder : Decoder<'model, 'r>) (doc : Y.Doc) : Result<'r, Error list> =
+        failwith "plan 0002: the v2 codec is implemented in Step 4"
+
+    type ObjectBuilder () =
+        member _.Return (x : 'a) : Decoder<'model, 'a> = DecoderStub
+        member _.ReturnFrom (d : Decoder<'model, 'a>) : Decoder<'model, 'a> = d
+        member _.Bind (d : Decoder<'model, 'a>, f : 'a -> Decoder<'model, 'b>) : Decoder<'model, 'b> = DecoderStub
+        member _.Zero () : Decoder<'model, unit> = DecoderStub
+        member _.Run (d : Decoder<'model, 'a>) : Decoder<'model, 'a> = d
+
+        /// Decode a property of the object by key; missing = MissingProperty.
+        member _.required (key : string) (d : Decoder<'model, 'a>) : Decoder<'model, 'a> = DecoderStub
+
+        /// Decode a property of the object by key; missing = None.
+        member _.optional (key : string) (d : Decoder<'model, 'a>) : Decoder<'model, 'a option> = DecoderStub
+
+    let object = ObjectBuilder ()

--- a/src/Ylmish/Codec.fs
+++ b/src/Ylmish/Codec.fs
@@ -143,10 +143,14 @@ module Encode =
     /// belong in `map` (L1).
     let list (encodeItem : Value.Encoder<'a>) (items : alist<'a>) : Encoded = EncodedStub
 
-    /// Presence/absence of any encoded position. None = the key is absent —
-    /// never null (a stored null is unreadable through the Fable binding's
-    /// `get`, see the Step 1 lesson).
-    let option (encodeSome : 'a -> Encoded) (a : aval<'a option>) : Encoded = EncodedStub
+    /// Presence/absence of any single-aval encoding, composing by name:
+    /// `Encode.option Encode.text m.Note`, `Encode.option Encode.string m.Nick`.
+    /// None = the key is ABSENT — never null (a stored null is unreadable
+    /// through the Fable binding's `get`, see the Step 1 lesson). None→Some
+    /// creates the backing type lazily at the transition (a local edit);
+    /// Some→None deletes the key, and delete beats concurrent edits inside
+    /// (U9). Collections have no aval view — an empty map/list is their "none".
+    let option (encodeSome : aval<'a> -> Encoded) (a : aval<'a option>) : Encoded = EncodedStub
 
     /// Deliberate wholesale-LWW replacement of an entire subtree (L8).
     let atomic (encoded : Encoded) : Encoded = EncodedStub

--- a/src/Ylmish/Program.fs
+++ b/src/Ylmish/Program.fs
@@ -157,6 +157,43 @@ let withYlmish (options : YlmishOptions<'model, 'amodel>) (program: Program<'arg
     program
     |> Program.map init update view setState subs termination
 
+// Plan 0002, Step 2b — target API skeleton for withYlmish v2. Nested under V2
+// so the running v1 above stays untouched until Step 7, which deletes v1 and
+// promotes these names (the nesting is scaffolding, not the final shape).
+[<RequireQualifiedAccess>]
+module V2 =
+
+    open Ylmish.Codec
+
+    /// Decode-failure policy: a malformed or newer-versioned doc must never
+    /// crash the loop — the current model stays in place and the errors go
+    /// here (plan 0002, open question 1).
+    type OnError = { Handle : Error list -> unit }
+
+    [<RequireQualifiedAccess>]
+    module OnError =
+        /// Log and keep the current model — the default policy.
+        let log : OnError = { Handle = fun _errors -> () }
+
+    type Options<'model, 'amodel> = {
+        Doc : Y.Doc
+        /// Adaptify-generated — the one place Adaptive remains on the surface.
+        Create : 'model -> 'amodel
+        Update : 'amodel -> 'model -> unit
+        Encode : 'amodel -> Encoded
+        Decode : Decoder<'model, 'model>
+        OnError : OnError
+    }
+
+    /// Bind an Elmish program to a Y.Doc through the v2 codec: containers are
+    /// created lazily on first local edit (decode-empty = init), local changes
+    /// flow as origin-tagged deltas, one remote transaction = one `Set`.
+    let withYlmish
+        (options : Options<'model, 'amodel>)
+        (program : Program<'arg, 'model, 'msg, 'view>)
+        : Program<'arg, 'model, Message<'model, 'msg>, 'view> =
+        failwith "plan 0002: withYlmish v2 is implemented in Step 7"
+
 // module Yjs.Adaptive.Elmish
 
 // module Codec = 

--- a/src/Ylmish/Text.fs
+++ b/src/Ylmish/Text.fs
@@ -1,0 +1,41 @@
+namespace Ylmish
+
+// Plan 0002, Step 2b — target API skeleton. Signatures are the deliverable;
+// bodies are stubs until Step 3. See doc/plans/0002-ylmish-redesign.md
+// ("`Ylmish.Text`").
+
+/// Collaboratively-edited text: an immutable value carrying content plus
+/// pending edit intent (splices), so the runtime can apply precise deltas to
+/// the backing Y.Text rather than guessing by diffing strings.
+///
+/// Equality and comparison are by CONTENT ONLY — pending intent is transport,
+/// not identity (plan 0002, open question 2). The runtime drains intents when
+/// flushing to the backing Y.Text and returns intent-free values on the way
+/// back in.
+type Text =
+    // Step 3 replaces this stub with content + pending intents, keeping
+    // content-only structural equality.
+    private
+    | TextStub
+
+[<RequireQualifiedAccess>]
+module Text =
+    let private nyi () : 'a = failwith "plan 0002: Ylmish.Text is implemented in Step 3"
+
+    let empty : Text = TextStub
+
+    let ofString (value : string) : Text = nyi ()
+    let toString (text : Text) : string = nyi ()
+    let length (text : Text) : int = nyi ()
+
+    // Intent-carrying edits — what Elmish update functions use.
+
+    let insert (at : int) (value : string) (text : Text) : Text = nyi ()
+    let remove (at : int) (count : int) (text : Text) : Text = nyi ()
+    let replace (at : int) (count : int) (value : string) (text : Text) : Text = nyi ()
+
+    /// Convenience for a plain <input>/<textarea> onChange: derives a single
+    /// splice from the old and new values by common prefix/suffix diff.
+    /// Ambiguous for repeated characters (documented; convergence unaffected);
+    /// the affix-diff strategy is validated minimal by lesson L3.
+    let edit (newValue : string) (text : Text) : Text = nyi ()

--- a/src/Ylmish/Y.fs
+++ b/src/Ylmish/Y.fs
@@ -503,6 +503,11 @@ module Element =
 module Doc =
     open FSharp.Data.Adaptive
 
+    // Alias for the v1 codec: the plan-0002 skeleton introduced the
+    // `Ylmish.Codec` namespace, which shadows unqualified `Codec.` references
+    // here. This whole materialize path is deleted in plan 0002 Step 7.
+    module V1 = Ylmish.Adaptive.Codec
+
     #if FABLE_COMPILER
     // Fable cannot perform runtime type tests on erased union cases
     [<Fable.Core.Emit("typeof $0 === 'string'")>]
@@ -519,10 +524,10 @@ module Doc =
     #endif
 
     /// Convert an Element<string> tree to a Y.Element tree
-    let rec private elementToY (element : Codec.Element<string>) : Y.Element =
+    let rec private elementToY (element : V1.Element<string>) : Y.Element =
         match element with
-        | Codec.Element.Value str -> Y.Element.String str
-        | Codec.Element.AList alist ->
+        | V1.Element.Value str -> Y.Element.String str
+        | V1.Element.AList alist ->
             let yarray = Y.Array.Create<Y.Element option> ()
             let items = AList.force alist |> IndexList.toList
             items |> List.iter (fun item ->
@@ -531,7 +536,7 @@ module Doc =
                 | None -> yarray.push [| None |] |> ignore
             )
             Y.Element.Array yarray
-        | Codec.Element.AMap amap ->
+        | V1.Element.AMap amap ->
             let ymap = Y.Map.Create<Y.Element option> ()
             AMap.force amap
             |> HashMap.iter (fun key value ->
@@ -541,22 +546,22 @@ module Doc =
             )
             Y.Element.Map ymap
 
-    /// Helper to convert any Y value (string, Y.Map, Y.Array) to Codec.Element
-    let rec private valueToElement (value : obj) : Codec.Element<string> =
+    /// Helper to convert any Y value (string, Y.Map, Y.Array) to V1.Element
+    let rec private valueToElement (value : obj) : V1.Element<string> =
         #if FABLE_COMPILER
         match () with
-        | _ when isString value -> Codec.Element.Value (unbox value)
+        | _ when isString value -> V1.Element.Value (unbox value)
         | _ when jsInstanceOf value jsYMap ->
             // It's a Y.Map<'T>, recursively convert its values
             let sourceMap = unbox<Y.Map<obj>> value
-            let mutable items = HashMap.empty<string, Codec.Element<string> option>
+            let mutable items = HashMap.empty<string, V1.Element<string> option>
             sourceMap.forEach (fun v k _ ->
                 if isNull v then
                     items <- HashMap.add k None items
                 else
                     items <- HashMap.add k (Some (valueToElement v)) items
             ) |> ignore
-            Codec.Element.AMap (AMap.ofHashMap items)
+            V1.Element.AMap (AMap.ofHashMap items)
         | _ when jsInstanceOf value jsYArray ->
             // It's a Y.Array<'T>, recursively convert its values
             let sourceArray = unbox<Y.Array<obj>> value
@@ -568,21 +573,21 @@ module Doc =
                 )
                 |> Seq.toList
                 |> IndexList.ofList
-            Codec.Element.AList (AList.ofIndexList items)
+            V1.Element.AList (AList.ofIndexList items)
         | _ -> failwith $"valueToElement: unsupported value type: %A{value}"
         #else
         match value with
-        | :? string as s -> Codec.Element.Value s
+        | :? string as s -> V1.Element.Value s
         | _ when value.GetType().Name.StartsWith("YMap") ->
             let sourceMap = unbox<Y.Map<obj>> value
-            let mutable items = HashMap.empty<string, Codec.Element<string> option>
+            let mutable items = HashMap.empty<string, V1.Element<string> option>
             sourceMap.forEach (fun v k _ ->
                 if isNull v then
                     items <- HashMap.add k None items
                 else
                     items <- HashMap.add k (Some (valueToElement v)) items
             ) |> ignore
-            Codec.Element.AMap (AMap.ofHashMap items)
+            V1.Element.AMap (AMap.ofHashMap items)
         | _ when value.GetType().Name.StartsWith("YArray") ->
             let sourceArray = unbox<Y.Array<obj>> value
             let items =
@@ -593,12 +598,12 @@ module Doc =
                 )
                 |> Seq.toList
                 |> IndexList.ofList
-            Codec.Element.AList (AList.ofIndexList items)
+            V1.Element.AList (AList.ofIndexList items)
         | _ -> failwith $"valueToElement: unsupported value type: %A{value}"
         #endif
 
     /// Materialize an Encoded Element tree into a Y.Doc's root map
-    let materialize (doc : Y.Doc) (encoded : Codec.Encoded<Codec.Element<string>>) : unit =
+    let materialize (doc : Y.Doc) (encoded : V1.Encoded<V1.Element<string>>) : unit =
         let rootMap = doc.getMap()
 
         // Force the encoded value to get the actual element tree
@@ -607,7 +612,7 @@ module Doc =
         | Some element ->
             // The root element should be an AMap (object)
             match element with
-            | Codec.Element.AMap amap ->
+            | V1.Element.AMap amap ->
                 doc.transact(fun _ ->
                     // Clear existing keys that aren't in the new map
                     let newKeys = AMap.force amap |> HashMap.toSeq |> Seq.map fst |> Set.ofSeq
@@ -633,17 +638,17 @@ module Doc =
             | _ -> failwith "Root element must be an AMap (object)"
 
     /// Dematerialize a Y.Doc's root map into an Element<string> tree
-    let dematerialize (doc : Y.Doc) : Codec.Element<string> =
+    let dematerialize (doc : Y.Doc) : V1.Element<string> =
         let rootMap = doc.getMap()
-        let mutable items = HashMap.empty<string, Codec.Element<string> option>
+        let mutable items = HashMap.empty<string, V1.Element<string> option>
 
         rootMap.forEach (fun value key _ ->
             // Check if value is null/undefined
             if isNull (box value) then
                 items <- HashMap.add key None items
             else
-                // Convert the value directly to Codec.Element
+                // Convert the value directly to V1.Element
                 items <- HashMap.add key (Some (valueToElement value)) items
         ) |> ignore
 
-        Codec.Element.AMap (AMap.ofHashMap items)
+        V1.Element.AMap (AMap.ofHashMap items)

--- a/src/Ylmish/Ylmish.fsproj
+++ b/src/Ylmish/Ylmish.fsproj
@@ -23,6 +23,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Disposables.fs" />
+		<Compile Include="Text.fs" />
+		<Compile Include="Codec.fs" />
 		<Compile Include="Adaptive.Codec.fs" />
 		<Compile Include="Y.fs" />
 		<Compile Include="Program.fs" />

--- a/tests/Ylmish.Tests/Harness.fs
+++ b/tests/Ylmish.Tests/Harness.fs
@@ -1,0 +1,332 @@
+module Ylmish.Harness
+
+// =============================================================================
+// Plan 0002, Step 2a — the differential harness (the plan's verification
+// backbone, L2). Adapted from the reference branch's Harness.fs (its plan 0006
+// Step 0), whose design transfers: no self-authored spec to be wrong about.
+//
+// Three ideas:
+//
+//   1. A `Bridge` is anything that can take a *whole immutable model* and push
+//      it into a Y.Doc (`Apply`), and read a converged model back out (`Read`).
+//      This is exactly the contract `withYlmish` has with the codec. Today's
+//      bridge is the `materialize`/`dematerialize` path; the oracle is a
+//      hand-written element-wise program directly on a `Y.Array`.
+//
+//   2. A `run` driver replays a schedule (per-replica ops + a delivery policy)
+//      against two docs wired with a bridge, exchanges Yjs updates, and reports
+//      the converged read-back on each replica. `Immediate` delivery ships each
+//      change before the next op (no concurrency window); `Concurrent` holds
+//      everything and exchanges once (maximal concurrency).
+//
+//   3. `differential` runs the system-under-test and the raw-Yjs oracle through
+//      the SAME schedule and compares converged membership. The oracle defines
+//      the intended CRDT semantics by construction.
+//
+// Step 2a's calibration triad (the tests at the bottom of this file):
+//   - GREEN on the oracle: ground truth holds (concurrent adds both survive).
+//   - CATCHES the known #83-class bug: the materialize path loses a concurrent
+//     add, and the harness names the lost id. (Expressed as a passing test that
+//     ASSERTS the mismatch — stronger than a pending test, and the suite stays
+//     green. When Step 5's binding layer fixes the bug, this test fails and is
+//     flipped into the fix's regression test.)
+//   - DISCRIMINATES: the same materialize path MATCHES the oracle when edits
+//     are sequential — the harness is not simply hostile to the old code.
+//
+// Also included (used from Step 5 onward): `incrementalBytes`/`measureApplies`,
+// the O(delta)-vs-O(state) minimality meter.
+// =============================================================================
+
+open FSharp.Data.Adaptive
+open Yjs
+
+open Ylmish
+open Ylmish.Adaptive.Codec
+
+// -----------------------------------------------------------------------------
+// Model + operations (membership core: Add/Remove of uniquely-identified items;
+// Edit/Move are in the alphabet so later steps extend the oracle, not the shape)
+// -----------------------------------------------------------------------------
+
+/// An item with a stable identity and a (future) collaborative text field.
+type Item = { Id : string; Text : string }
+
+type Model = Item list
+
+type Op =
+    | Add of id : string * text : string
+    | Remove of id : string
+    | Edit of id : string * text : string
+    | Move of id : string * toIndex : int
+
+/// The pure MVU `update`. Adds are idempotent on id (set membership).
+let applyOp (m : Model) (op : Op) : Model =
+    match op with
+    | Add (id, text) ->
+        if m |> List.exists (fun i -> i.Id = id) then m
+        else m @ [ { Id = id; Text = text } ]
+    | Remove id -> m |> List.filter (fun i -> i.Id <> id)
+    | Edit (id, text) ->
+        m |> List.map (fun i -> if i.Id = id then { i with Text = text } else i)
+    | Move (id, toIndex) ->
+        match m |> List.tryFind (fun i -> i.Id = id) with
+        | None -> m
+        | Some item ->
+            let without = m |> List.filter (fun i -> i.Id <> id)
+            let idx = max 0 (min toIndex (List.length without))
+            (without |> List.take idx) @ [ item ] @ (without |> List.skip idx)
+
+/// Membership as a set of ids — the no-loss comparison.
+let idSet (m : Model) : Set<string> = m |> List.map (fun i -> i.Id) |> Set.ofList
+
+// -----------------------------------------------------------------------------
+// Bridge contract
+// -----------------------------------------------------------------------------
+
+/// Whole immutable models in, a converged model out — `withYlmish`'s contract.
+type Bridge =
+    { Name : string
+      Doc : Y.Doc
+      Apply : Model -> unit
+      Read : unit -> Model }
+
+type BridgeFactory = Y.Doc -> Bridge
+
+// -----------------------------------------------------------------------------
+// Bridge 1 — today's materialize/dematerialize path (the system-under-test the
+// harness must catch being wrong; replaced by the binding layer in Step 5).
+// -----------------------------------------------------------------------------
+
+module Materialize =
+    let private encodeModel (m : Model) : Encoded<Element<string>> =
+        let ids = m |> List.map (fun i -> i.Id)
+        Encode.object [
+            "items", Encode.list (fun (s : string) -> Encode.value id (AVal.constant s)) (AList.ofList ids)
+        ]
+
+    let private decoder : Decoder<Model, Element<string>, Model> =
+        Decode.object {
+            let! items = Decode.object.required "items" (Decode.list.required Decode.value)
+            return
+                items
+                |> IndexList.toList
+                |> List.map (fun o -> { Id = string o; Text = "" })
+        }
+
+    let factory : BridgeFactory =
+        fun doc ->
+            { Name = "materialize"
+              Doc = doc
+              Apply = fun m -> Y.Doc.materialize doc (encodeModel m)
+              Read =
+                fun () ->
+                    let demat = Y.Doc.dematerialize doc
+                    match Decode.run ([] : Model) decoder (AVal.constant (Some demat)) |> AVal.force with
+                    | Ok m -> m
+                    | Error e -> failwithf "materialize read: decode failed: %A" e }
+
+// -----------------------------------------------------------------------------
+// Bridge 2 — the raw-Yjs ORACLE (ground truth). Element-wise on a stable
+// root `Y.Array` of ids: an Add is one insert, a Remove one delete. The array
+// keeps its identity and accumulates ops, so concurrent adds both survive —
+// the intended CRDT semantics, by construction (U2b/U8).
+// -----------------------------------------------------------------------------
+
+module RawYjs =
+    let factory : BridgeFactory =
+        fun doc ->
+            let arr : Y.Array<obj> = doc.getArray "items"
+            let currentIds () = arr.toArray () |> Seq.map string |> Seq.toList
+            { Name = "rawYjs"
+              Doc = doc
+              Read = fun () -> currentIds () |> List.map (fun id -> { Id = id; Text = "" })
+              Apply =
+                fun m ->
+                    let want = m |> List.map (fun i -> i.Id)
+                    let wantSet = Set.ofList want
+                    doc.transact (fun _ ->
+                        let cur = currentIds ()
+                        let curSet = Set.ofList cur
+                        // Delete unwanted ids, highest index first so indices stay valid.
+                        cur
+                        |> List.mapi (fun i id -> i, id)
+                        |> List.filter (fun (_, id) -> not (Set.contains id wantSet))
+                        |> List.map fst
+                        |> List.sortDescending
+                        |> List.iter (fun i -> arr.delete (float i, 1.0))
+                        for id in want do
+                            if not (Set.contains id curSet) then arr.push [| box id |]) }
+
+// -----------------------------------------------------------------------------
+// Schedule driver
+// -----------------------------------------------------------------------------
+
+type ReplicaOp = { Replica : int; Op : Op }
+
+/// `Immediate`: each local change ships to the peer before the next op (no
+/// concurrency window). `Concurrent`: hold everything, exchange once at the end.
+type Delivery =
+    | Immediate
+    | Concurrent
+
+type RunResult =
+    { Final : Model []        // converged read-back per replica
+      Converged : bool        // replicas agree (by id-set)
+      Ids : Set<string>[] }   // per-replica membership, for differential checks
+
+/// Full-state exchange i -> j. Full-state updates are idempotent and
+/// order-independent, so partition/duplication/reordering come for free.
+let private syncFromTo (docs : Y.Doc[]) i j =
+    Y.applyUpdate (docs.[j], Y.encodeStateAsUpdate docs.[i], box "remote")
+
+let private syncAll (docs : Y.Doc[]) =
+    for _ in 1 .. 2 do
+        syncFromTo docs 0 1
+        syncFromTo docs 1 0
+
+let run (factory : BridgeFactory) (delivery : Delivery) (ops : ReplicaOp list) : RunResult =
+    let docs = [| Y.Doc.Create (); Y.Doc.Create () |]
+    let bridges = docs |> Array.map factory
+    let models = [| ([] : Model); ([] : Model) |]
+
+    // Deliver i -> j, then refresh replica j's model from the converged Y state —
+    // this is `withYlmish`'s remote-update → read-back → `Set` loop. Modelling it
+    // is what makes the harness fair: without it even sequential edits would
+    // "lose", and the concurrent loss it reports would not be a CRDT-layer fact.
+    let deliver i j =
+        syncFromTo docs i j
+        models.[j] <- bridges.[j].Read ()
+
+    for { Replica = i; Op = op } in ops do
+        models.[i] <- applyOp models.[i] op
+        bridges.[i].Apply models.[i]
+        match delivery with
+        | Immediate ->
+            deliver i (1 - i)
+            deliver (1 - i) i
+        | Concurrent -> ()
+
+    syncAll docs
+
+    let final = bridges |> Array.map (fun b -> b.Read ())
+    let ids = final |> Array.map idSet
+    { Final = final
+      Converged = ids.[0] = ids.[1]
+      Ids = ids }
+
+// -----------------------------------------------------------------------------
+// Differential check: SUT vs the raw-Yjs oracle on the same schedule
+// -----------------------------------------------------------------------------
+
+type Diff =
+    { Converged : bool          // SUT replicas agree
+      OracleIds : Set<string>   // ground-truth membership
+      SutIds : Set<string>      // SUT membership (replica 0 after convergence)
+      MatchesOracle : bool
+      Lost : Set<string> }      // ids the oracle kept but the SUT dropped
+
+let differential (sut : BridgeFactory) (delivery : Delivery) (ops : ReplicaOp list) : Diff =
+    let s = run sut delivery ops
+    let o = run RawYjs.factory delivery ops
+    let oracleIds = o.Ids.[0]
+    let sutIds = s.Ids.[0]
+    { Converged = s.Converged
+      OracleIds = oracleIds
+      SutIds = sutIds
+      MatchesOracle = sutIds = oracleIds
+      Lost = Set.difference oracleIds sutIds }
+
+// -----------------------------------------------------------------------------
+// Minimality meter (used from Step 5): incremental Yjs update bytes per apply.
+// -----------------------------------------------------------------------------
+
+/// Bytes a single `apply` adds to the doc. Element-wise bridges are O(delta);
+/// whole-tree materialization is O(state).
+let incrementalBytes (doc : Y.Doc) (apply : unit -> unit) : int =
+    let svBefore = Y.encodeStateVectorFromUpdate (Y.encodeStateAsUpdate doc)
+    apply ()
+    let inc = Y.encodeStateAsUpdate (doc, svBefore)
+    int inc.length
+
+let measureApplies (factory : BridgeFactory) (models : Model list) : int list =
+    let doc = Y.Doc.Create ()
+    let bridge = factory doc
+    models |> List.map (fun m -> incrementalBytes doc (fun () -> bridge.Apply m))
+
+// -----------------------------------------------------------------------------
+// Step 2a calibration triad — proves the harness is trustworthy.
+// -----------------------------------------------------------------------------
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+let private add r id = { Replica = r; Op = Add (id, "") }
+
+let tests = testList "Harness" [
+    testList "Step 2a calibration" [
+
+        // GREEN ON THE ORACLE: ground truth holds. If this failed, the oracle
+        // itself would be wrong and nothing downstream could be trusted.
+        test "oracle: two concurrent adds both survive (ground truth is no-loss)" {
+            let ops = [ add 0 "a"; add 1 "b" ]
+            let r = run RawYjs.factory Concurrent ops
+            Expect.isTrue r.Converged "oracle replicas must converge"
+            Expect.equal r.Ids.[0] (Set.ofList [ "a"; "b" ])
+                "element-wise Yjs keeps BOTH concurrent adds — the intended semantics"
+        }
+
+        // CATCHES THE KNOWN BUG (issue #83's class): differential testing
+        // reports intention loss on the materialize path and names the lost id.
+        // NB: asserted as a mismatch so the suite stays green while pinning that
+        // the harness catches it. Step 5 flips this into a regression test.
+        test "materialize path: loses a concurrent add — and the harness catches it" {
+            let ops = [ add 0 "a"; add 1 "b" ]
+            let d = differential Materialize.factory Concurrent ops
+            Expect.equal d.OracleIds (Set.ofList [ "a"; "b" ]) "oracle keeps both (ground truth)"
+            Expect.isFalse d.MatchesOracle
+                "the materialize path must DISAGREE with the oracle — if this fails, either the bug is fixed (move this assertion) or the harness is blind"
+            Expect.isNonEmpty (Set.toList d.Lost)
+                "the harness pinpoints the lost id (whole-tree LWW dropped one peer's add)"
+            Expect.equal (Set.count d.SutIds) 1
+                "whole-tree LWW: exactly one peer's single-item array survives"
+        }
+
+        // DISCRIMINATES: with no concurrency window the same materialize path
+        // matches the oracle — the harness is not simply hostile to the old code.
+        test "materialize path: matches the oracle when edits are sequential" {
+            let ops = [ add 0 "a"; add 1 "b" ]
+            let d = differential Materialize.factory Immediate ops
+            Expect.isTrue d.MatchesOracle "no concurrency window: read-back folds the remote add in"
+            Expect.equal d.SutIds (Set.ofList [ "a"; "b" ]) "both items present sequentially"
+        }
+
+        // Convergence alone is not correctness: the materialize path CONVERGES
+        // on the lossy state. This is why the differential check, not
+        // convergence, is the real gate.
+        test "materialize path: converges, but on the wrong (lossy) state" {
+            let r = run Materialize.factory Concurrent [ add 0 "a"; add 1 "b" ]
+            Expect.isTrue r.Converged "both replicas reach the same state"
+            Expect.equal (Set.count r.Ids.[0]) 1 "that state has lost an item"
+        }
+
+        // Minimality meter sanity (the Step 5 perf gate, calibrated now):
+        // adding 1 item on top of 20 — the oracle ships one insert, the
+        // materialize path re-ships the whole array.
+        test "minimality meter: oracle add is O(delta), materialize is O(state)" {
+            let models =
+                [ 0 .. 20 ]
+                |> List.map (fun n ->
+                    [ 0 .. n - 1 ] |> List.map (fun k -> { Id = sprintf "item-%02d" k; Text = "" }))
+            let rawSizes = measureApplies RawYjs.factory models
+            let materializeSizes = measureApplies Materialize.factory models
+            let rawLast = List.last rawSizes
+            let materializeLast = List.last materializeSizes
+            Expect.isTrue (rawLast < materializeLast)
+                (sprintf "adding 1 item to 20: oracle=%d bytes (O(delta)) must be smaller than materialize=%d bytes (O(state))"
+                    rawLast materializeLast)
+        }
+    ]
+]

--- a/tests/Ylmish.Tests/NorthStar.fs
+++ b/tests/Ylmish.Tests/NorthStar.fs
@@ -1,0 +1,152 @@
+module Ylmish.NorthStar
+
+// Plan 0002, Step 2b — the north-star acceptance tests, written against the
+// TARGET public API and skipped (ptestCase) until Step 7 un-skips them. Their
+// job today is to force the API surface to exist and to read well as consumer
+// code; their job at Step 7 is to close issue #83 by test.
+//
+// The model here is hand-written adaptive (cval/cmap), NOT Adaptify-generated:
+// Step 3 owns proving `[<ModelType>]` works with a Text field, and 2b must not
+// take on codegen risk. The shape mirrors the plan's consumer sketch.
+
+open FSharp.Data.Adaptive
+open Yjs
+
+open Ylmish
+open Ylmish.Codec
+
+#if FABLE_COMPILER
+open Fable.Mocha
+#else
+open Expecto
+#endif
+
+// --- The consumer's model: plain immutable record; Text is the only Ylmish type.
+
+type Model = {
+    Body : Text                      // collaborative: concurrent edits merge
+    Todos : HashMap<string, string>  // keyed by app-minted id ⇒ element-wise merge
+    Filter : string                  // app-only: never encoded, never synced
+}
+
+module Model =
+    let init = { Body = Text.empty; Todos = HashMap.empty; Filter = "" }
+
+type Msg =
+    | EditBody of (Text -> Text)
+    | AddTodo of id : string * title : string
+    | SetFilter of string
+
+let update (msg : Msg) (m : Model) =
+    match msg with
+    | EditBody f -> { m with Body = f m.Body }, Elmish.Cmd.none
+    | AddTodo (id, title) -> { m with Todos = HashMap.add id title m.Todos }, Elmish.Cmd.none
+    | SetFilter f -> { m with Filter = f }, Elmish.Cmd.none
+
+// --- Hand-written adaptive companion (what Adaptify generates from Step 3 on).
+
+type AdaptiveModel (m : Model) =
+    let body = cval m.Body
+    let todos = cmap (HashMap.toSeq m.Todos)
+    member _.Body = body :> aval<Text>
+    member _.Todos = todos :> amap<string, string>
+    member _.Update (m : Model) =
+        body.Value <- m.Body
+        todos.Value <- m.Todos
+    static member Create (m : Model) = AdaptiveModel m
+
+// --- The codec: one word per field is the merge choice; Filter is absent.
+
+module Codec =
+    let encode (am : AdaptiveModel) : Encoded =
+        Encode.object [
+            "body", Encode.text am.Body
+            "todos", Encode.map (fun (title : string) -> Encode.string (AVal.constant title)) am.Todos
+        ]
+
+    let decode : Decoder<Model, Model> =
+        Decode.object {
+            let! model = Decode.ask
+            let! body = Decode.object.optional "body" Decode.text
+            let! todos = Decode.object.optional "todos" (Decode.map Decode.string)
+            return
+                { model with
+                    Body = defaultArg body Text.empty
+                    Todos = defaultArg todos HashMap.empty }
+        }
+
+// --- Wiring: two independent programs over two docs, synced explicitly.
+
+let private makeProgram (doc : Y.Doc) =
+    Elmish.Program.mkProgram (fun () -> Model.init, Elmish.Cmd.none) update (fun _ _ -> ())
+    |> Ylmish.Program.V2.withYlmish {
+        Doc = doc
+        Create = AdaptiveModel.Create
+        Update = fun am m -> am.Update m
+        Encode = Codec.encode
+        Decode = Codec.decode
+        OnError = Ylmish.Program.V2.OnError.log
+    }
+
+let private user msg = Ylmish.Program.Message.User msg
+
+let private syncBoth (a : Y.Doc) (b : Y.Doc) =
+    Y.applyUpdate (b, Y.encodeStateAsUpdate a)
+    Y.applyUpdate (a, Y.encodeStateAsUpdate b)
+
+let tests = testList "NorthStar" [
+
+    // Issue #83's acceptance: concurrent edits to the same text field converge
+    // to an interleaved result IN THE ELMISH MODELS, not just the docs.
+    ptestCase "concurrent Text edits converge interleaved across two withYlmish programs" (fun () ->
+        let d1 = Y.Doc.Create ()
+        let d2 = Y.Doc.Create ()
+        use p1 = Elmish.Program.test (makeProgram d1)
+        use p2 = Elmish.Program.test (makeProgram d2)
+
+        // Shared starting text, created by one peer and synced.
+        p1.Dispatch (user (EditBody (Text.edit "hello")))
+        syncBoth d1 d2
+
+        // Offline: both edit the same field concurrently...
+        p1.Dispatch (user (EditBody (Text.insert 5 " world")))
+        p2.Dispatch (user (EditBody (Text.insert 0 "oh, ")))
+        // ...then the network heals.
+        syncBoth d1 d2
+
+        Expect.equal (Text.toString p1.Model.Body) "oh, hello world"
+            "both peers' edits survive, interleaved (U3) — the #83 headline"
+        Expect.equal (Text.toString p2.Model.Body) (Text.toString p1.Model.Body)
+            "both models converge")
+
+    // The accepted-limitation rule, demonstrated positively: offline creation
+    // is safe because todos are keyed by app-minted unique ids (Encode.map).
+    ptestCase "keyed-map concurrent adds both survive (offline creation with app-minted ids)" (fun () ->
+        let d1 = Y.Doc.Create ()
+        let d2 = Y.Doc.Create ()
+        use p1 = Elmish.Program.test (makeProgram d1)
+        use p2 = Elmish.Program.test (makeProgram d2)
+
+        p1.Dispatch (user (AddTodo ("id-1", "buy milk")))
+        p2.Dispatch (user (AddTodo ("id-2", "walk dog")))
+        syncBoth d1 d2
+
+        Expect.equal (HashMap.count p1.Model.Todos) 2 "both offline creations survive on p1"
+        Expect.equal p1.Model.Todos p2.Model.Todos "and the models converge")
+
+    // Leave what you don't own (U15): a full session against a doc carrying a
+    // key this codec doesn't know must not destroy that key.
+    ptestCase "unknown keys survive a full withYlmish session" (fun () ->
+        let d1 = Y.Doc.Create ()
+        (d1.getMap () : Y.Map<obj>).set ("someone-elses-key", box "v1-data") |> ignore
+
+        use p1 = Elmish.Program.test (makeProgram d1)
+        p1.Dispatch (user (EditBody (Text.edit "hello")))
+        p1.Dispatch (user (AddTodo ("id-1", "buy milk")))
+        p1.Dispatch (user (SetFilter "done"))   // app-only: must not sync either
+
+        let root : Y.Map<obj> = d1.getMap ()
+        Expect.equal (root.get "someone-elses-key" |> Option.map string) (Some "v1-data")
+            "keys the encoder doesn't mention are never touched"
+        Expect.isFalse (root.has "filter") "app-only fields never reach the doc")
+]

--- a/tests/Ylmish.Tests/NorthStar.fs
+++ b/tests/Ylmish.Tests/NorthStar.fs
@@ -25,12 +25,13 @@ open Expecto
 
 type Model = {
     Body : Text                      // collaborative: concurrent edits merge
+    Note : Text option               // optional collaborative text: None = key absent
     Todos : HashMap<string, string>  // keyed by app-minted id ⇒ element-wise merge
     Filter : string                  // app-only: never encoded, never synced
 }
 
 module Model =
-    let init = { Body = Text.empty; Todos = HashMap.empty; Filter = "" }
+    let init = { Body = Text.empty; Note = None; Todos = HashMap.empty; Filter = "" }
 
 type Msg =
     | EditBody of (Text -> Text)
@@ -47,11 +48,14 @@ let update (msg : Msg) (m : Model) =
 
 type AdaptiveModel (m : Model) =
     let body = cval m.Body
+    let note = cval m.Note
     let todos = cmap (HashMap.toSeq m.Todos)
     member _.Body = body :> aval<Text>
+    member _.Note = note :> aval<Text option>
     member _.Todos = todos :> amap<string, string>
     member _.Update (m : Model) =
         body.Value <- m.Body
+        note.Value <- m.Note
         todos.Value <- m.Todos
     static member Create (m : Model) = AdaptiveModel m
 
@@ -61,6 +65,7 @@ module Codec =
     let encode (am : AdaptiveModel) : Encoded =
         Encode.object [
             "body", Encode.text am.Body
+            "note", Encode.option Encode.text am.Note
             "todos", Encode.map (fun (title : string) -> Encode.string (AVal.constant title)) am.Todos
         ]
 
@@ -68,10 +73,12 @@ module Codec =
         Decode.object {
             let! model = Decode.ask
             let! body = Decode.object.optional "body" Decode.text
+            let! note = Decode.object.optional "note" Decode.text
             let! todos = Decode.object.optional "todos" (Decode.map Decode.string)
             return
                 { model with
                     Body = defaultArg body Text.empty
+                    Note = note
                     Todos = defaultArg todos HashMap.empty }
         }
 

--- a/tests/Ylmish.Tests/Ylmish.Tests.fs
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fs
@@ -13,6 +13,7 @@ let tests = [
    Y.Doc.tests
    Y.Assumptions.tests
    Harness.tests
+   NorthStar.tests
    Program.tests
    TodoCollaborative.tests
 ]

--- a/tests/Ylmish.Tests/Ylmish.Tests.fs
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fs
@@ -12,6 +12,7 @@ let tests = [
    Y.Element.tests
    Y.Doc.tests
    Y.Assumptions.tests
+   Harness.tests
    Program.tests
    TodoCollaborative.tests
 ]

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="Y.Element.fs" />
     <Compile Include="Y.Doc.fs" />
     <Compile Include="Y.Assumptions.fs" />
+    <Compile Include="Harness.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="TodoCollaborative.fs" />
     <Compile Include="Ylmish.Tests.fs" />

--- a/tests/Ylmish.Tests/Ylmish.Tests.fsproj
+++ b/tests/Ylmish.Tests/Ylmish.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Y.Doc.fs" />
     <Compile Include="Y.Assumptions.fs" />
     <Compile Include="Harness.fs" />
+    <Compile Include="NorthStar.fs" />
     <Compile Include="Program.fs" />
     <Compile Include="TodoCollaborative.fs" />
     <Compile Include="Ylmish.Tests.fs" />


### PR DESCRIPTION
## Step 2a — differential harness (the verification backbone, L2)

`tests/Ylmish.Tests/Harness.fs`, adapted from the reference branch: a `Bridge` contract (whole immutable models in, converged model out), a schedule driver with `Immediate`/`Concurrent` delivery, a `differential` runner against a raw-Yjs oracle, and the O(delta)-vs-O(state) minimality meter.

Calibration triad, committed as tests:
- **green on the oracle** — two concurrent adds both survive (ground truth);
- **catches the known #83-class bug** — the materialize path loses a concurrent add and the harness names the lost id (asserted as a mismatch so the suite stays green; Step 5 flips it into the fix's regression test);
- **discriminates** — the same materialize path matches the oracle when edits are sequential.

## Step 2b — target API skeleton + skipped north stars (design-review checkpoint)

The v2 public surface as compiling signatures with inert stub bodies: `Ylmish.Text` (intent-carrying text value), `Ylmish.Codec` (the `Value` primitive sub-language as `Value.Encode.*`/`Value.Decode.*`, opaque `Encoded`/`Decoder`, the full combinator set including keyed `map`, `atomic`, adaptive `option`, and the `CustomElement`/`BindContext` escape hatch with real Fable.Yjs types), and `Ylmish.Program.V2` (options record + `withYlmish`, nested so v1 keeps running until Step 7).

Three north-star acceptance tests compile against this surface as consumer code and are skipped (`ptestCase`) until Step 7: concurrent `Text` edits interleave across two programs (#83's acceptance), keyed-map offline creations both survive, unknown keys survive a session. Review resolutions folded in: `Value` submodule shape confirmed; `Encode.option` takes an adaptive inner encoder so `Text option` is expressible (`Encode.option Encode.text m.Note`), with the Some-window projection named as a Step 5 risk.

**Suite: 130 passing, 3 pending** (the north stars). Interpretation decisions are recorded in the plan doc's Step 2b check-in notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKxgiTophokAKjqMX2toS

---
_Generated by [Claude Code](https://claude.ai/code/session_013RKxgiTophokAKjqMX2toS)_