### PR TITLE
Reword TODO: Quickstart wants less faff, not a specific style

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,10 +14,12 @@
    `None` via a normal item edit, and assert the key disappears from the item's
    `Y.Map` on both peers.
 
-1. **Rewrite the README's Quickstart in the Background sections' writing style.**
+1. **Rewrite the README's Quickstart with less faff.**
 
-   The Background sections state problems and reason to a design; the Quickstart
-   currently reads like feature narration. Bring them to one voice.
+   The Background sections are plain and direct; the Quickstart narrates —
+   bold signposting, "That's the whole integration…" asides, selling each
+   snippet. Trim it to the same register: show the code, say what it does,
+   move on.
 
 1. **Cut the running commentary of history from README.md and doc/guides/.**
 


### PR DESCRIPTION
Corrects TODO item 2 per Nick: the Quickstart rewrite isn't about problem-first reasoning specifically — it's about cutting the narration (bold signposting, "that's the whole integration…" asides) down to the Background sections' plain register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RKxgiTophokAKjqMX2toS

---
_Generated by [Claude Code](https://claude.ai/code/session_013RKxgiTophokAKjqMX2toS)_