### PR TITLE
Add GetXmlFragment to BindContext for custom elements

### DIFF
--- a/doc/guides/custom-elements.md
+++ b/doc/guides/custom-elements.md
@@ -22,7 +22,7 @@ A `CustomElement` has two members:
 
 - **`Connect : BindContext -> IDisposable`** — called once when the runtime
   attaches your program to the doc. The `BindContext` gives you
-  `GetText ()` / `GetMap ()` / `GetArray ()` — get-or-adopt accessors that
+  `GetText ()` / `GetMap ()` / `GetArray ()` / `GetXmlFragment ()` — get-or-adopt accessors that
   always return the **one** integrated instance (calling twice returns the
   same object, so you cannot corrupt the doc by re-integrating) — and
   `Origin`, the token your writes must be transacted under.

--- a/src/Fable.Yjs/Yjs.fs
+++ b/src/Fable.Yjs/Yjs.fs
@@ -2023,6 +2023,7 @@ module Y =
     type Text = Types.YText.YText
     type Map<'a> = Types.YMap.YMap<'a>
     type Array<'a> = Types.YArray.YArray<'a>
+    type XmlFragment = Types.YXmlFragment.YXmlFragment
     type AbstractType = Types.AbstractType.AbstractType<obj>
     type Transaction = Utils.Transaction.Transaction
     

--- a/src/Ylmish/Binding.fs
+++ b/src/Ylmish/Binding.fs
@@ -50,12 +50,16 @@ let private jsYArray : obj = obj ()
 [<Fable.Core.Import("Map", "yjs")>]
 let private jsYMap : obj = obj ()
 
+[<Fable.Core.Import("XmlFragment", "yjs")>]
+let private jsYXmlFragment : obj = obj ()
+
 [<Fable.Core.Emit("$0 instanceof $1")>]
 let private jsInstanceOf (_x : obj) (_ctor : obj) : bool = false
 
 let private isYText (v : obj) = jsInstanceOf v jsYText
 let private isYMap (v : obj) = jsInstanceOf v jsYMap
 let private isYArray (v : obj) = jsInstanceOf v jsYArray
+let private isYXmlFragment (v : obj) = jsInstanceOf v jsYXmlFragment
 
 let private plainObject (fields : (string * obj) list) : obj =
     Fable.Core.JsInterop.createObj fields
@@ -66,6 +70,7 @@ let private plainArray (items : obj list) : obj =
 let private isYText (v : obj) = v.GetType().Name.StartsWith "YText"
 let private isYMap (v : obj) = v.GetType().Name.StartsWith "YMap"
 let private isYArray (v : obj) = v.GetType().Name.StartsWith "YArray"
+let private isYXmlFragment (v : obj) = v.GetType().Name.StartsWith "YXmlFragment"
 
 let private plainObject (fields : (string * obj) list) : obj =
     box (dict fields)
@@ -91,6 +96,7 @@ let private drift path expectedKind (found : obj) =
     let foundKind =
         if isYText found then "a Y.Text"
         elif isYArray found then "a Y.Array"
+        elif isYXmlFragment found then "a Y.XmlFragment"
         elif isYMap found then "a Y.Map"
         else "a plain value"
     raise (SchemaDrift (UnexpectedKind (path, sprintf "the doc holds %s where the schema expects %s — schema drift" foundKind expectedKind)))
@@ -127,6 +133,17 @@ let private ensureArray (parent : EnsureMap) (key : string) (path : Path) : unit
             let a : Y.Array<obj> = Y.Array.Create ()
             p.set (key, box a) |> ignore
             a
+
+let private ensureXmlFragment (parent : EnsureMap) (key : string) (path : Path) : unit -> Y.XmlFragment =
+    fun () ->
+        let p = parent ()
+        match p.get key with
+        | Some v when isYXmlFragment v -> unbox<Y.XmlFragment> v
+        | Some v -> drift path "an xml fragment" v
+        | None ->
+            let f : Y.XmlFragment = Y.XmlFragment.Create ()
+            p.set (key, box f) |> ignore
+            f
 
 // -----------------------------------------------------------------------------
 // Text: apply drained intents as precise splices.
@@ -473,6 +490,7 @@ and private attachCustom (attachment : Attachment) (parent : EnsureMap) (key : s
         { GetText = fun () -> ensureText parent key path () |> fst
           GetMap = fun () -> ensureChildMap parent key path ()
           GetArray = fun () -> ensureArray parent key path ()
+          GetXmlFragment = fun () -> ensureXmlFragment parent key path ()
           Origin = attachment.Origin }
     attachment.Add (custom.Connect ctx)
 
@@ -511,6 +529,7 @@ let attach (doc : Y.Doc) (encoded : Encoded) : Attachment =
                     { GetText = fun () -> doc.getText k
                       GetMap = fun () -> doc.getMap k
                       GetArray = fun () -> doc.getArray k
+                      GetXmlFragment = fun () -> doc.getXmlFragment k
                       Origin = attachment.Origin }
                 attachment.Add (custom.Connect ctx)
             | EncValue _ | EncOption _ | EncAtomic _ ->

--- a/src/Ylmish/Codec.fs
+++ b/src/Ylmish/Codec.fs
@@ -115,6 +115,9 @@ type BindContext =
     { GetText : unit -> Y.Text
       GetMap : unit -> Y.Map<obj>
       GetArray : unit -> Y.Array<obj>
+      /// Get-or-create this element's slot as a Y.XmlFragment — the anchor an
+      /// XML editor binding (e.g. y-prosemirror) owns and mutates directly.
+      GetXmlFragment : unit -> Y.XmlFragment
       /// The origin token local writes must be transacted under — echo
       /// suppression (U6), and the seam Y.UndoManager integration would use.
       Origin : obj }

--- a/tests/Ylmish.Tests/CustomElements.fs
+++ b/tests/Ylmish.Tests/CustomElements.fs
@@ -72,15 +72,35 @@ type EditorSurface () =
 // sample:end editor-surface
 
 // =============================================================================
+// CONSUMER CODE — a rich-text surface: hands the live, integrated Y.XmlFragment
+// to a structured editor (a y-prosemirror binding). The editor mutates the
+// fragment directly; the model receives the merged structure through decode.
+// The observable Value here is the child count — a stand-in for "the document".
+// =============================================================================
+
+type XmlEditorSurface () =
+    let mutable fragment : Y.XmlFragment option = None
+    /// The live Y.XmlFragment — what you would hand to y-prosemirror.
+    member _.Fragment = Option.get fragment
+    interface CustomElement with
+        member _.Connect ctx =
+            fragment <- Some (ctx.GetXmlFragment ())
+            { new IDisposable with member _.Dispose () = () }
+        member _.Value =
+            match fragment with
+            | Some f -> box ((f.toArray ()).Count)
+            | None -> box 0
+
+// =============================================================================
 // Wiring (test-side): a model with a counter, an editor draft, and a register.
 // =============================================================================
 
 open FSharp.Data.Adaptive   // test-side only: the hand-written adaptive model
 
-type Model = { Hits : int; Draft : string; Note : string }
+type Model = { Hits : int; Draft : string; Note : string; Body : int }
 
 module Model =
-    let init = { Hits = 0; Draft = ""; Note = "" }
+    let init = { Hits = 0; Draft = ""; Note = ""; Body = 0 }
 
 type Msg =
     | Bump
@@ -95,6 +115,7 @@ type private Peer = {
     Doc : Y.Doc
     Counter : GrowOnlyCounter
     Editor : EditorSurface
+    Body : XmlEditorSurface
     Dispatcher : Elmish.Program.ElmishDispatcher<Model, Ylmish.Program.Message<Model, Msg>>
 }
 
@@ -102,6 +123,7 @@ let private mkPeer () =
     let doc = Y.Doc.Create ()
     let counter = GrowOnlyCounter ()
     let editor = EditorSurface ()
+    let body = XmlEditorSurface ()
     let update msg (m : Model) =
         match msg with
         | Bump -> { m with Hits = m.Hits + 1 }, Elmish.Cmd.ofEffect (fun _ -> counter.Bump ())
@@ -110,6 +132,7 @@ let private mkPeer () =
         Encode.object [
             "hits", Encode.custom counter
             "draft", Encode.custom editor
+            "body", Encode.custom body
             "note", Encode.string am.Note
         ]
     let decode : Decoder<Model, Model> =
@@ -117,8 +140,9 @@ let private mkPeer () =
             let! model = Decode.ask
             let! hits = Decode.object.required "hits" Decode.custom
             let! draft = Decode.object.required "draft" Decode.custom
+            let! bodyCount = Decode.object.required "body" Decode.custom
             let! note = Decode.object.optional "note" Decode.string
-            return { model with Hits = hits; Draft = draft; Note = defaultArg note model.Note }
+            return { model with Hits = hits; Draft = draft; Body = bodyCount; Note = defaultArg note model.Note }
         }
     let program =
         Elmish.Program.mkProgram (fun () -> Model.init, Elmish.Cmd.none) update (fun _ _ -> ())
@@ -133,6 +157,7 @@ let private mkPeer () =
     { Doc = doc
       Counter = counter
       Editor = editor
+      Body = body
       Dispatcher = Elmish.Program.test program }
 
 let private user msg = Ylmish.Program.Message.User msg
@@ -140,6 +165,10 @@ let private user msg = Ylmish.Program.Message.User msg
 let private syncBoth (a : Y.Doc) (b : Y.Doc) =
     Y.applyUpdate (b, Y.encodeStateAsUpdate a, box "test-remote")
     Y.applyUpdate (a, Y.encodeStateAsUpdate b, box "test-remote")
+
+/// Append one element child to a fragment — a y-prosemirror stand-in.
+let private pushChild (f : Y.XmlFragment) (name : string) =
+    f.push [| Fable.Core.U2.Case1 (Y.XmlElement.Create name) |]
 
 let tests = testList "CustomElement (the escape hatch, end-to-end)" [
 
@@ -183,6 +212,53 @@ let tests = testList "CustomElement (the escape hatch, end-to-end)" [
         syncBoth p1.Doc p2.Doc
         Expect.equal p1.Dispatcher.Model.Draft "oh, hello world" "interleaved (U3)"
         Expect.equal p2.Dispatcher.Model.Draft p1.Dispatcher.Model.Draft "converged"
+    }
+
+    test "the xml editor scenario: external edits to the handed-out Y.XmlFragment flow into the model and merge" {
+        let p1 = mkPeer ()
+        let p2 = mkPeer ()
+        use _d1 = p1.Dispatcher
+        use _d2 = p2.Dispatcher
+
+        // The "editor" (a y-prosemirror stand-in) writes DIRECTLY to the live
+        // Y.XmlFragment, knowing nothing of Ylmish.
+        pushChild p1.Body.Fragment "paragraph"
+        Expect.equal p1.Dispatcher.Model.Body 1
+            "the editor's own insert flowed into the model through the ordinary decode path"
+
+        syncBoth p1.Doc p2.Doc
+        Expect.equal p2.Dispatcher.Model.Body 1 "and reached the peer's model"
+
+        // Concurrent inserts from both editors both survive (fragment inserts
+        // merge like array inserts, U8) — a structural merge no register gives.
+        pushChild p1.Body.Fragment "heading"
+        pushChild p2.Body.Fragment "list"
+        syncBoth p1.Doc p2.Doc
+        Expect.equal p1.Dispatcher.Model.Body 3 "both concurrent inserts kept, not last-writer-wins"
+        Expect.equal p2.Dispatcher.Model.Body p1.Dispatcher.Model.Body "and both models converge"
+    }
+
+    test "a nested custom anchors its Y.XmlFragment in the parent map (ensureXmlFragment)" {
+        let doc = Y.Doc.Create ()
+        let mutable frag : Y.XmlFragment option = None
+        let bodyEl =
+            { new CustomElement with
+                member _.Connect ctx =
+                    frag <- Some (ctx.GetXmlFragment ())
+                    { new IDisposable with member _.Dispose () = () }
+                member _.Value = box 0 }
+        // "body" is a custom nested inside the "draft" object — this routes the
+        // BindContext through attachCustom (the nested Get* site).
+        use _att =
+            Ylmish.Internal.Binding.attach doc
+                (Encode.object [ "draft", Encode.object [ "body", Encode.custom bodyEl ] ])
+        pushChild (Option.get frag) "paragraph"
+        // The very fragment the editor mutated lives at draft.body in the doc.
+        let draft : Y.Map<obj> = doc.getMap "draft"
+        match draft.get "body" with
+        | Some v -> Expect.equal ((unbox<Y.XmlFragment> v).toArray().Count) 1
+                        "the edited fragment is anchored under draft.body"
+        | None -> failwith "expected a Y.XmlFragment under draft.body"
     }
 
     test "BindContext never double-integrates: repeated Get* return the one instance (U5)" {


### PR DESCRIPTION
## Summary

Custom elements can now anchor a live `Y.XmlFragment` (race-free, idempotent), so a consumer can hand the real fragment to an XML editor binding such as `y-prosemirror` — the XML analogue of the existing `GetText` editor scenario. The Ylmish sync boundary stays intact: the rich body remains an `Encode.custom` field, encoded as an `XmlFragment` rather than reaching around the codec for a raw Yjs type.

This reuses the existing `Encode.custom` / `CustomElement` machinery entirely — the decode path needed no changes.

## Changes

- **`src/Fable.Yjs/Yjs.fs`** — expose the `Y.XmlFragment` type alias in `module Y` (the static constructor and `Doc.getXmlFragment` already existed).
- **`src/Ylmish/Codec.fs`** — add `GetXmlFragment : unit -> Y.XmlFragment` to `BindContext`.
- **`src/Ylmish/Binding.fs`** — add the `isYXmlFragment` guard (both compile branches) and an `ensureXmlFragment` slot helper (mirroring `ensureArray`); wire `GetXmlFragment` into both the top-level (`doc.getXmlFragment k`) and nested (`ensureXmlFragment`) `BindContext` construction sites; extend the `drift` kind ladder.
- **`tests/Ylmish.Tests/CustomElements.fs`** — a consumer `XmlEditorSurface` (the y-prosemirror analogue of `EditorSurface`), plus an end-to-end two-peer scenario (concurrent fragment inserts merge) and a nested-anchoring test for `ensureXmlFragment`.
- **`doc/guides/custom-elements.md`** — list `GetXmlFragment` among the `BindContext` accessors.

## Verification

- `npm test` → **113 passing** (both new tests plus all pre-existing).
- `npm run docs:check` → all 17 doc sample regions in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkXcaKUmDDwVF7g29gkMMj)_